### PR TITLE
MRD-2005 Use hmpps-common-vars for validate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,8 @@ workflows:
           filters:
             tags:
               ignore: /.*/
+          context:
+            - hmpps-common-vars
           <<: *slack-fail-post-step
       - hmpps/helm_lint:
           name: helm_lint


### PR DESCRIPTION
This is to get access to the SONAR_TOKEN variable