### PR TITLE
Add stdout and stderr to test output

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,10 @@ tasks {
 
 tasks.test {
   finalizedBy(tasks.jacocoTestReport)
+  this.testLogging {
+    // Add this so that we get more information on test failures for integration tests, particularly in the pipeline
+    this.showStandardStreams = true
+  }
 }
 
 tasks.jacocoTestReport {


### PR DESCRIPTION
This should allow us to more easily see what has gone wrong in the integration tests because otherwise we
just get the assertion failure stack trace and no details of exceptions etc. from within the service