### PR TITLE
Reduce log clutter in tests

### DIFF
--- a/src/test/resources/logback-spring.xml
+++ b/src/test/resources/logback-spring.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <property name="LOG_PATTERN"
+            value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m | %mdc %n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+  <springProperty scope="context" name="app" source="spring.application.name"/>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <root level="ERROR">
+    <appender-ref ref="consoleAppender"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Tests are outputting stdout and stderr so that exceptions in integration tests can be seen.  This meant the test output was very cluttered with logging.  Reducing log level combats that.