### PR TITLE
MRD-2258 Add recommendedTo to recall request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/PpudUser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/PpudUser.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain
+
+import jakarta.validation.constraints.NotBlank
+
+data class PpudUser(
+  @field:NotBlank
+  val fullName: String,
+  @field:NotBlank
+  val teamName: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateRecallRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateRecallRequest.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.request
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.PpudUser
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.RiskOfSeriousHarmLevel
 import java.time.LocalDateTime
 
@@ -16,8 +18,13 @@ data class CreateRecallRequest(
   @field:NotBlank
   val probationArea: String,
   val receivedDateTime: LocalDateTime,
-  @field:NotBlank
-  val recommendedToOwner: String,
+  val recommendedTo: PpudUser = PpudUser("", ""),
+  @Deprecated(message = "This has now been superseded by recommendedTo so that name and team are passed in separately.")
+  @field:Schema(
+    deprecated = true,
+    description = "The PPUD user who is booking on the recall, in the format <name>(<team name>)",
+  )
+  val recommendedToOwner: String = "${recommendedTo.fullName}(${recommendedTo.teamName})",
   val riskOfContrabandDetails: String = "",
   @field:NotNull
   val riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/PpudClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/PpudClientTest.kt
@@ -18,6 +18,7 @@ import org.mockito.kotlin.willReturnConsecutively
 import org.openqa.selenium.NotFoundException
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebDriver.Navigation
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.PpudUser
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.CreatedOffender
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.CreatedSentence
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.SearchResultOffender
@@ -42,6 +43,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generateCrea
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generateCreateOrUpdateSentenceRequest
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generateCreateRecallRequest
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generateOffender
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generatePpudUser
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generateRecall
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generateSearchResultOffender
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.generateUpdateOffenceRequest
@@ -804,10 +806,11 @@ class PpudClientTest {
       val offenderId = randomPpudId()
       val releaseId = randomPpudId()
       val receivedDateTime = LocalDateTime.now()
-      val recommendedToOwner = randomString("recommendedToOwner")
+      val recommendedTo = PpudUser(randomString("fullName"), randomString("teamName"))
+      val recommendedToOwner = "${recommendedTo.fullName}(${recommendedTo.teamName})"
       val createRecallRequest = generateCreateRecallRequest(
         receivedDateTime = receivedDateTime,
-        recommendedToOwner = recommendedToOwner,
+        recommendedTo = recommendedTo,
       )
       val matchingRecallLink = "/link/to/matching/recall"
       val recallId = randomPpudId()
@@ -840,10 +843,11 @@ class PpudClientTest {
       val offenderId = randomPpudId()
       val releaseId = randomPpudId()
       val receivedDateTime = LocalDateTime.now()
-      val recommendedToOwner = randomString("recommendedToOwner")
+      val recommendedTo = generatePpudUser()
+      val recommendedToOwner = "${recommendedTo.fullName}(${recommendedTo.teamName})"
       val createRecallRequest = generateCreateRecallRequest(
         receivedDateTime = receivedDateTime,
-        recommendedToOwner = recommendedToOwner,
+        recommendedTo = recommendedTo,
       )
       val nonMatchingRecallLink = "/link/to/non-matching/recall"
       val recallId = randomPpudId()
@@ -876,10 +880,11 @@ class PpudClientTest {
       val offenderId = randomPpudId()
       val releaseId = randomPpudId()
       val receivedDateTime = LocalDateTime.now()
-      val recommendedToOwner = randomString("recommendedToOwner")
+      val recommendedTo = generatePpudUser()
+      val recommendedToOwner = "${recommendedTo.fullName}(${recommendedTo.teamName})"
       val createRecallRequest = generateCreateRecallRequest(
         receivedDateTime = receivedDateTime,
-        recommendedToOwner = recommendedToOwner,
+        recommendedTo = recommendedTo,
       )
       val nonMatchingRecallLink = "/link/to/non-matching/recall"
       val persistedRecallLink = "/link/to/persisted/recall"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata
 
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.PpudUser
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.Offender
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.OffenderAddress
@@ -50,9 +51,11 @@ const val PPUD_VALID_RELEASED_UNDER = "CJA 1991"
 
 const val PPUD_VALID_RELEASED_UNDER_2 = "CJA 2008"
 
-const val PPUD_VALID_USER_FULL_NAME_AND_TEAM = "Consider a Recall Test(Recall 1)"
-
 const val PPUD_VALID_USER_FULL_NAME = "Consider a Recall Test"
+
+const val PPUD_VALID_USER_TEAM = "Recall 1"
+
+const val PPUD_VALID_USER_FULL_NAME_AND_TEAM = "$PPUD_VALID_USER_FULL_NAME($PPUD_VALID_USER_TEAM)"
 
 const val PPUD_IMMIGRATION_STATUS = "Not Applicable"
 
@@ -303,7 +306,7 @@ fun generateCreateRecallRequest(
   isExtendedSentence: Boolean? = null,
   isInCustody: Boolean? = null,
   receivedDateTime: LocalDateTime = randomTimeToday(),
-  recommendedToOwner: String = randomString("recommendedToOwner"),
+  recommendedTo: PpudUser = generatePpudUser(),
   riskOfContrabandDetails: String? = null,
   riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel? = null,
 ): CreateRecallRequest {
@@ -315,7 +318,7 @@ fun generateCreateRecallRequest(
     policeForce = randomString("policeForce"),
     probationArea = randomString("probationArea"),
     receivedDateTime = receivedDateTime,
-    recommendedToOwner = recommendedToOwner,
+    recommendedTo = recommendedTo,
     riskOfContrabandDetails = riskOfContrabandDetails ?: randomString("riskOfContrabandDetails"),
     riskOfSeriousHarmLevel = riskOfSeriousHarmLevel ?: randomRiskOfSeriousHarmLevel(),
   )
@@ -337,5 +340,12 @@ fun generateRecall(id: String = randomPpudId()): Recall {
     recommendedToOwner = randomString("recommendedToOwner"),
     returnToCustodyNotificationMethod = randomString("returnToCustodyNotificationMethod"),
     revocationIssuedByOwner = randomString("revocationIssuedByOwner"),
+  )
+}
+
+fun generatePpudUser(): PpudUser {
+  return PpudUser(
+    fullName = randomString("fullName"),
+    teamName = randomString("teamName"),
   )
 }


### PR DESCRIPTION
This is still supporting the string recommendedToOwner for now but allows us to pass in separate name and team name so that callers need not be concerned with how PPUD formats/handles this field.