### PR TITLE
Schedule Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,8 @@
       "groupName": "all non major Gradle dependencies",
       "groupSlug": "all-gradle-minor-patch"
     }
+  ],
+  "schedule": [
+    "between 7am and 7pm every weekday"
   ]
 }


### PR DESCRIPTION
This is to avoid running pipelines when PPUD is not available for tests.