### PR TITLE
Verify/wait for offender page after saving new offender

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClient.kt
@@ -218,6 +218,7 @@ internal class OperationalPpudClient(
     newOffenderPage.verifyOn()
     newOffenderPage.createOffender(createOffenderRequest)
     newOffenderPage.throwIfInvalid()
+    offenderPage.verifyOn()
     offenderPage.updateAdditionalAddresses(createOffenderRequest.additionalAddresses)
     offenderPage.throwIfInvalid()
     return offenderPage.extractCreatedOffenderDetails(::extractCreatedSentence)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/OffenderPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/OffenderPage.kt
@@ -5,7 +5,9 @@ import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.support.FindBy
 import org.openqa.selenium.support.PageFactory
+import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.Select
+import org.openqa.selenium.support.ui.WebDriverWait
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.CreatedOffender
@@ -22,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.ppud.pages.helpers.Pa
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.ppud.pages.helpers.PageHelper.Companion.getValue
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.selenium.TreeView
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.util.YoungOffenderCalculator
+import java.time.Duration
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -156,6 +159,16 @@ internal class OffenderPage(
   fun viewOffenderWithId(offenderId: String) {
     driver.navigate().to("$ppudUrl/Offender/PersonalDetails.aspx?data=$offenderId")
     throwIfErrorViewingOffender()
+  }
+
+  fun verifyOn() {
+    WebDriverWait(driver, Duration.ofSeconds(10))
+      .until(
+        ExpectedConditions.and(
+          ExpectedConditions.urlContains("PersonalDetails.aspx"),
+          ExpectedConditions.visibilityOf(prisonNumberInput),
+        ),
+      )
   }
 
   fun updateOffender(updateOffenderRequest: UpdateOffenderRequest) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClientTest.kt
@@ -483,6 +483,7 @@ class OperationalPpudClientTest {
       then(newOffenderPage).should(inOrder).verifyOn()
       then(newOffenderPage).should(inOrder).createOffender(createOffenderRequest)
       then(newOffenderPage).should(inOrder).throwIfInvalid()
+      then(offenderPage).should(inOrder).verifyOn()
       then(offenderPage).should(inOrder).updateAdditionalAddresses(any())
       then(offenderPage).should(inOrder).throwIfInvalid()
     }


### PR DESCRIPTION
Performance tests had a couple of errored requests where the offender page (PersonalDetails.aspx) wasn't displayed after creating the offender. Theory is that this may just be PPUD being slow.