### PR TITLE
Avoid WebDriverManager shutdown hook

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/ComponentConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/ComponentConfiguration.kt
@@ -179,6 +179,10 @@ internal class ComponentConfiguration {
 
     options.addPreference("permissions.default.image", FIREFOX_PREFERENCE_BLOCK)
 
-    return WebDriverManager.firefoxdriver().capabilities(options).create()
+    return WebDriverManager
+      .firefoxdriver()
+      .capabilities(options)
+      .avoidShutdownHook()
+      .create()
   }
 }


### PR DESCRIPTION
This should hopefully mean that requests that are already in progress are allowed to complete when a pod shuts down.