### PR TITLE
MRD-2495 Creating test recall uses random date time

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_R
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_USER_FULL_NAME
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_USER_TEAM
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomDate
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomDateTime
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomPhoneNumber
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomString
@@ -213,7 +214,7 @@ abstract class IntegrationTestBase {
     }
 
     fun createRecallRequestBody(
-      decisionDateTime: String = randomTimeToday().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+      decisionDateTime: String = randomDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
       isInCustody: String = "false",
       isExtendedSentence: String = "false",
       mappaLevel: String = PPUD_VALID_MAPPA_LEVEL,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.ppud.LookupName
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.random.Random
 
@@ -119,6 +120,13 @@ fun randomPrisonNumber(): String {
 
 fun randomDate(): LocalDate {
   return LocalDate.parse("2005-01-01").minusDays(Random.nextLong(SIXTY_YEARS_IN_DAYS))
+}
+
+fun randomDateTime(): LocalDateTime {
+  val earliest = LocalDateTime.parse("2000-01-01T00:00:00")
+  val latest = LocalDateTime.now()
+  val randomEpochSecond = Random.nextLong(earliest.toEpochSecond(ZoneOffset.UTC), latest.toEpochSecond(ZoneOffset.UTC))
+  return LocalDateTime.ofEpochSecond(randomEpochSecond, 0, ZoneOffset.UTC)
 }
 
 fun randomTimeToday(): LocalDateTime {


### PR DESCRIPTION
This is to avoid the situation where a fresh recall is not created in tests that expect it.  The rules around being idempotent mean that a fresh recall is only created when the receivedDateTime and recommendedToOwner are unique. It is now highly unlikely that the same receivedDateTime will be passed in.