### PR TITLE
Bump non major dep versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.9"
-  kotlin("plugin.spring") version "2.0.21"
-  id("org.sonarqube") version "6.0.0.5145"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.2"
+  kotlin("plugin.spring") version "2.1.0"
+  id("org.sonarqube") version "6.0.1.5171"
   id("jacoco")
 }
 
@@ -20,13 +20,13 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
-  implementation("org.seleniumhq.selenium:selenium-java:4.26.0")
+  implementation("org.seleniumhq.selenium:selenium-java:4.27.0")
   implementation("io.github.bonigarcia:webdrivermanager:5.9.2")
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
-  implementation("commons-io:commons-io:2.17.0") // Address CVE-2021-29425
+  implementation("commons-io:commons-io:2.18.0") // Address CVE-2021-29425
 
   // OAuth dependencies
   implementation("org.springframework.boot:spring-boot-starter-security")
@@ -34,7 +34,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
   // OpenAPI dependencies
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
 
   implementation("org.bouncycastle:bcprov-jdk18on:1.79") // Address CVE-2024-29857, CVE-2024-30172, CVE-2024-30171 present in 1.76
 
@@ -65,4 +65,8 @@ tasks.jacocoTestReport {
   reports {
     xml.required.set(true)
   }
+}
+
+ktlint {
+  version = "1.5.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,7 @@ tasks.test {
   }
 }
 
+
 tasks.jacocoTestReport {
   dependsOn(tasks.test)
   reports {
@@ -67,6 +68,7 @@ tasks.jacocoTestReport {
   }
 }
 
+// this is to address JLLeitschuh/ktlint-gradle#809
 ktlint {
   version = "1.5.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,6 @@ tasks.test {
   }
 }
 
-
 tasks.jacocoTestReport {
   dependsOn(tasks.test)
   reports {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/AuthAwareTokenConverter.kt
@@ -20,12 +20,10 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
     return AuthAwareAuthenticationToken(jwt, principal, authorities)
   }
 
-  private fun findPrincipal(claims: Map<String, Any?>): String {
-    return if (claims.containsKey("user_name")) {
-      claims["user_name"] as String
-    } else {
-      claims["client_id"] as String
-    }
+  private fun findPrincipal(claims: Map<String, Any?>): String = if (claims.containsKey("user_name")) {
+    claims["user_name"] as String
+  } else {
+    claims["client_id"] as String
   }
 
   private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> {
@@ -44,7 +42,5 @@ class AuthAwareAuthenticationToken(
   private val aPrincipal: String,
   authorities: Collection<GrantedAuthority>,
 ) : JwtAuthenticationToken(jwt, authorities) {
-  override fun getPrincipal(): String {
-    return aPrincipal
-  }
+  override fun getPrincipal(): String = aPrincipal
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/CacheConfiguration.kt
@@ -13,9 +13,7 @@ class CacheConfiguration {
   var timeToLiveSeconds: Long = 20
 
   @Bean
-  fun defaultRedisCacheConfiguration(): RedisCacheConfiguration {
-    return RedisCacheConfiguration
-      .defaultCacheConfig()
-      .entryTtl(Duration.ofSeconds(timeToLiveSeconds))
-  }
+  fun defaultRedisCacheConfiguration(): RedisCacheConfiguration = RedisCacheConfiguration
+    .defaultCacheConfig()
+    .entryTtl(Duration.ofSeconds(timeToLiveSeconds))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/ComponentConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/ComponentConfiguration.kt
@@ -45,18 +45,14 @@ internal class ComponentConfiguration {
   fun referenceService(
     referenceDataPpudClient: ReferenceDataPpudClient,
     cacheManager: CacheManager,
-  ): ReferenceService {
-    return ReferenceServiceImpl(referenceDataPpudClient, cacheManager)
-  }
+  ): ReferenceService = ReferenceServiceImpl(referenceDataPpudClient, cacheManager)
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   fun scheduledReferenceService(
     @Qualifier("scheduledReferenceDataPpudClient") scheduledReferenceDataPpudClient: ReferenceDataPpudClient,
     cacheManager: CacheManager,
-  ): ReferenceService {
-    return ReferenceServiceImpl(scheduledReferenceDataPpudClient, cacheManager)
-  }
+  ): ReferenceService = ReferenceServiceImpl(scheduledReferenceDataPpudClient, cacheManager)
 
   @Bean
   @Primary
@@ -73,22 +69,20 @@ internal class ComponentConfiguration {
     @Value("\${ppud.reference.valueToExclude}") valueToExclude: String,
     adminPage: AdminPage,
     editLookupsPage: EditLookupsPage,
-  ): ReferenceDataPpudClient {
-    return ReferenceDataPpudClient(
-      ppudUrl,
-      ppudUsername,
-      ppudPassword,
-      ppudAdminUsername,
-      ppudAdminPassword,
-      driver,
-      errorPage,
-      loginPage,
-      searchPage,
-      valueToExclude,
-      adminPage,
-      editLookupsPage,
-    )
-  }
+  ): ReferenceDataPpudClient = ReferenceDataPpudClient(
+    ppudUrl,
+    ppudUsername,
+    ppudPassword,
+    ppudAdminUsername,
+    ppudAdminPassword,
+    driver,
+    errorPage,
+    loginPage,
+    searchPage,
+    valueToExclude,
+    adminPage,
+    editLookupsPage,
+  )
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -101,22 +95,20 @@ internal class ComponentConfiguration {
     @Qualifier("scheduledWebDriver") driver: WebDriver,
     @Value("\${ppud.reference.valueToExclude}") valueToExclude: String,
     dateFormatter: DateTimeFormatter,
-  ): ReferenceDataPpudClient {
-    return ReferenceDataPpudClient(
-      ppudUrl,
-      ppudUsername,
-      ppudPassword,
-      ppudAdminUsername,
-      ppudAdminPassword,
-      driver,
-      ErrorPage(driver, PageHelper(driver, dateFormatter)),
-      LoginPage(driver),
-      SearchPage(driver),
-      valueToExclude,
-      AdminPage(driver),
-      EditLookupsPage(driver),
-    )
-  }
+  ): ReferenceDataPpudClient = ReferenceDataPpudClient(
+    ppudUrl,
+    ppudUsername,
+    ppudPassword,
+    ppudAdminUsername,
+    ppudAdminPassword,
+    driver,
+    ErrorPage(driver, PageHelper(driver, dateFormatter)),
+    LoginPage(driver),
+    SearchPage(driver),
+    valueToExclude,
+    AdminPage(driver),
+    EditLookupsPage(driver),
+  )
 
   @Bean(destroyMethod = "quit")
   @Primary
@@ -124,18 +116,14 @@ internal class ComponentConfiguration {
   fun webDriver(
     @Value("\${automation.headless}") headless: Boolean,
     @Value("\${automation.firefox.binary}") binary: String?,
-  ): WebDriver {
-    return createWebDriver(binary, headless)
-  }
+  ): WebDriver = createWebDriver(binary, headless)
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   fun scheduledWebDriver(
     @Value("\${automation.headless}") headless: Boolean,
     @Value("\${automation.firefox.binary}") binary: String?,
-  ): WebDriver {
-    return createWebDriver(binary, headless)
-  }
+  ): WebDriver = createWebDriver(binary, headless)
 
   @Bean
   fun dateFormatter(): DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
@@ -167,7 +155,5 @@ internal class ComponentConfiguration {
   }
 
   @Bean
-  fun uuidProvider(): () -> UUID {
-    return { UUID.randomUUID() }
-  }
+  fun uuidProvider(): () -> UUID = { UUID.randomUUID() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/WebClientConfiguration.kt
@@ -40,17 +40,15 @@ class WebClientConfiguration(
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
 
-    fun <T> Mono<T>.withRetry(): Mono<T> {
-      return this
-        .retryWhen(
-          Retry.backoff(2, Duration.ofMillis(500))
-            .filter(::shouldBeRetried)
-            .doBeforeRetry(::logRetrySignal)
-            .onRetryExhaustedThrow { _, retrySignal ->
-              retrySignal.failure()
-            },
-        )
-    }
+    fun <T> Mono<T>.withRetry(): Mono<T> = this
+      .retryWhen(
+        Retry.backoff(2, Duration.ofMillis(500))
+          .filter(::shouldBeRetried)
+          .doBeforeRetry(::logRetrySignal)
+          .onRetryExhaustedThrow { _, retrySignal ->
+            retrySignal.failure()
+          },
+      )
 
     private fun logRetrySignal(retrySignal: Retry.RetrySignal) {
       val exception = retrySignal.failure()?.cause ?: retrySignal.failure()
@@ -69,12 +67,10 @@ class WebClientConfiguration(
       499,
     )
 
-    private fun shouldBeRetried(ex: Throwable): Boolean {
-      return ex is ClientTimeoutException ||
-        ex is TimeoutException ||
-        ex is WebClientRequestException ||
-        (ex is WebClientResponseException && transientStatusCodes.contains(ex.statusCode.value()))
-    }
+    private fun shouldBeRetried(ex: Throwable): Boolean = ex is ClientTimeoutException ||
+      ex is TimeoutException ||
+      ex is WebClientRequestException ||
+      (ex is WebClientResponseException && transientStatusCodes.contains(ex.statusCode.value()))
   }
 
   @Bean
@@ -126,9 +122,7 @@ class WebClientConfiguration(
   }
 
   @Bean
-  fun documentManagementApiClient(@Qualifier("documentManagementApiWebClientAppScope") webClient: WebClient): DocumentManagementClient {
-    return DocumentManagementClient(webClient, documentManagementTimeout)
-  }
+  fun documentManagementApiClient(@Qualifier("documentManagementApiWebClientAppScope") webClient: WebClient): DocumentManagementClient = DocumentManagementClient(webClient, documentManagementTimeout)
 
   private fun getOAuthWebClient(
     authorizedClientManager: OAuth2AuthorizedClientManager,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparator.kt
@@ -6,15 +6,13 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.request.Create
 
 @Component
 class SentenceComparator {
-  fun areMatching(existing: Sentence, request: CreateOrUpdateSentenceRequest): Boolean {
-    return existing.dateOfSentence == request.dateOfSentence &&
-      existing.custodyType == request.custodyType &&
-      existing.sentencingCourt == request.sentencingCourt &&
-      existing.mappaLevel == request.mappaLevel &&
-      existing.sentenceLength?.partYears == request.sentenceLength?.partYears &&
-      existing.sentenceLength?.partMonths == request.sentenceLength?.partMonths &&
-      existing.sentenceLength?.partDays == request.sentenceLength?.partDays &&
-      existing.licenceExpiryDate == request.licenceExpiryDate &&
-      existing.sentenceExpiryDate == request.sentenceExpiryDate
-  }
+  fun areMatching(existing: Sentence, request: CreateOrUpdateSentenceRequest): Boolean = existing.dateOfSentence == request.dateOfSentence &&
+    existing.custodyType == request.custodyType &&
+    existing.sentencingCourt == request.sentencingCourt &&
+    existing.mappaLevel == request.mappaLevel &&
+    existing.sentenceLength?.partYears == request.sentenceLength?.partYears &&
+    existing.sentenceLength?.partMonths == request.sentenceLength?.partMonths &&
+    existing.sentenceLength?.partDays == request.sentenceLength?.partDays &&
+    existing.licenceExpiryDate == request.licenceExpiryDate &&
+    existing.sentenceExpiryDate == request.sentenceExpiryDate
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PingHealthCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PingHealthCheck.kt
@@ -34,17 +34,12 @@ abstract class PingHealthCheck(
     return result
   }
 
-  private fun upWithStatus(it: ResponseEntity<String>): Mono<Health> =
-    Mono.just(Health.up().withHttpStatus(it.statusCode).build())
+  private fun upWithStatus(it: ResponseEntity<String>): Mono<Health> = Mono.just(Health.up().withHttpStatus(it.statusCode).build())
 
-  private fun downWithException(it: Exception): Health {
-    return Health.down().withException(it).build()
-  }
+  private fun downWithException(it: Exception): Health = Health.down().withException(it).build()
 
-  private fun downWithResponseBody(it: WebClientResponseException): Health {
-    return Health.down().withException(it).withBody(it.responseBodyAsString).withHttpStatus(it.statusCode)
-      .build()
-  }
+  private fun downWithResponseBody(it: WebClientResponseException): Health = Health.down().withException(it).withBody(it.responseBodyAsString).withHttpStatus(it.statusCode)
+    .build()
 
   private fun Health.Builder.withHttpStatus(status: HttpStatusCode) = this.withDetail("status", status)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClient.kt
@@ -401,13 +401,11 @@ internal class OperationalPpudClient(
     return sentencePage.extractCreatedSentenceDetails()
   }
 
-  private fun extractSentences(): (List<String>) -> List<Sentence> {
-    return { urls ->
-      urls.map {
-        driver.navigate().to("$ppudUrl$it")
-        val sentencePage = sentencePageFactory.sentencePage()
-        sentencePage.extractSentenceDetails(::extractOffenceDetails)
-      }
+  private fun extractSentences(): (List<String>) -> List<Sentence> = { urls ->
+    urls.map {
+      driver.navigate().to("$ppudUrl$it")
+      val sentencePage = sentencePageFactory.sentencePage()
+      sentencePage.extractSentenceDetails(::extractOffenceDetails)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/PpudClientBase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/PpudClientBase.kt
@@ -80,27 +80,23 @@ internal abstract class PpudClientBase(
     }
   }
 
-  private suspend fun <T> (suspend () -> T).invokeWithRetry(): T {
-    return try {
-      this()
-    } catch (ex: WebDriverException) {
-      val exceptionToLog = wrapWebDriverException(ex)
-      log.error("Exception occurred but operation will be retried.", exceptionToLog)
-      this()
-    }
+  private suspend fun <T> (suspend () -> T).invokeWithRetry(): T = try {
+    this()
+  } catch (ex: WebDriverException) {
+    val exceptionToLog = wrapWebDriverException(ex)
+    log.error("Exception occurred but operation will be retried.", exceptionToLog)
+    this()
   }
 
-  private fun wrapWebDriverException(ex: WebDriverException): AutomationException {
-    return if (errorPage.isShown()) {
-      PpudErrorException(
-        "PPUD has displayed an error. Details are: '${errorPage.extractErrorDetails()}'",
-        ex,
-      )
-    } else {
-      AutomationException(
-        "Exception occurred when performing PPUD operation. Current URL is '${driver.currentUrl}'",
-        ex,
-      )
-    }
+  private fun wrapWebDriverException(ex: WebDriverException): AutomationException = if (errorPage.isShown()) {
+    PpudErrorException(
+      "PPUD has displayed an error. Details are: '${errorPage.extractErrorDetails()}'",
+      ex,
+    )
+  } else {
+    AutomationException(
+      "Exception occurred when performing PPUD operation. Current URL is '${driver.currentUrl}'",
+      ex,
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/ReferenceDataPpudClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/ReferenceDataPpudClient.kt
@@ -49,17 +49,13 @@ internal class ReferenceDataPpudClient(
     }
   }
 
-  private suspend fun extractLookupValues(lookupName: LookupName): List<String> {
-    return if (lookupName == LookupName.Genders) {
-      extractGenderLookupValues()
-    } else {
-      extractAdminPageLookupValues(lookupName)
-    }
+  private suspend fun extractLookupValues(lookupName: LookupName): List<String> = if (lookupName == LookupName.Genders) {
+    extractGenderLookupValues()
+  } else {
+    extractAdminPageLookupValues(lookupName)
   }
 
-  private fun extractGenderLookupValues(): List<String> {
-    return searchPage.genderValues()
-  }
+  private fun extractGenderLookupValues(): List<String> = searchPage.genderValues()
 
   private fun extractAdminPageLookupValues(lookupName: LookupName): List<String> {
     driver.navigate().to("$ppudUrl${adminPage.urlPath}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/CaseworkerAdminPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/CaseworkerAdminPage.kt
@@ -82,13 +82,9 @@ internal class CaseworkerAdminPage(
     return users
   }
 
-  private fun getPageLink(nextPageNum: Number): WebElement? {
-    return resultsTable?.findElements(By.xpath("tbody/tr[last()]/td/table/tbody/tr/td/a[text()='$nextPageNum']"))?.firstOrNull()
-  }
+  private fun getPageLink(nextPageNum: Number): WebElement? = resultsTable?.findElements(By.xpath("tbody/tr[last()]/td/table/tbody/tr/td/a[text()='$nextPageNum']"))?.firstOrNull()
 
-  private fun getForwardEllipsisLink(): WebElement? {
-    return resultsTable?.findElements(By.xpath("tbody/tr[last()]/td/table/tbody/tr/td[last()]/a[text()='...']"))?.firstOrNull()
-  }
+  private fun getForwardEllipsisLink(): WebElement? = resultsTable?.findElements(By.xpath("tbody/tr[last()]/td/table/tbody/tr/td[last()]/a[text()='...']"))?.firstOrNull()
 
   private fun resetPage() {
     pageHelper.selectDropdownOptionIfNotBlank(roleDropdown, "Level 1", "role")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/ErrorPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/ErrorPage.kt
@@ -15,16 +15,12 @@ internal class ErrorPage(
   private val body: WebElement?
     get() = driver.findElements(By.xpath("//body")).firstOrNull()
 
-  fun isShown(): Boolean {
-    return pageHelper.isCustomErrorUrl() ||
-      body?.text?.startsWith("Server Error in") == true
-  }
+  fun isShown(): Boolean = pageHelper.isCustomErrorUrl() ||
+    body?.text?.startsWith("Server Error in") == true
 
-  fun extractErrorDetails(): String {
-    return if (pageHelper.isCustomErrorUrl()) {
-      "An error has occurred"
-    } else {
-      driver.title
-    }
+  fun extractErrorDetails(): String = if (pageHelper.isCustomErrorUrl()) {
+    "An error has occurred"
+  } else {
+    driver.title.orEmpty()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/OffenderPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/OffenderPage.kt
@@ -222,13 +222,11 @@ internal class OffenderPage(
     pageHelper.dismissConfirmDeleteAlert()
   }
 
-  fun extractCreatedOffenderDetails(sentenceExtractor: (String) -> CreatedSentence): CreatedOffender {
-    return CreatedOffender(
-      id = extractOffenderId(),
-      // Do sentence last because it navigates away
-      sentence = sentenceExtractor(determineSentenceLinks().first()),
-    )
-  }
+  fun extractCreatedOffenderDetails(sentenceExtractor: (String) -> CreatedSentence): CreatedOffender = CreatedOffender(
+    id = extractOffenderId(),
+    // Do sentence last because it navigates away
+    sentence = sentenceExtractor(determineSentenceLinks().first()),
+  )
 
   fun extractSearchResultOffenderDetails(): SearchResultOffender? {
     val offenderId = extractOffenderId()
@@ -250,29 +248,27 @@ internal class OffenderPage(
     }
   }
 
-  fun extractOffenderDetails(sentenceExtractor: (List<String>) -> List<Sentence>): Offender {
-    return Offender(
-      id = extractOffenderId(),
-      address = extractAddress(),
-      caseworker = caseworkerInput.getValue(),
-      comments = commentsTextArea.getValue(),
-      croOtherNumber = croOtherNumberInput.getValue(),
-      dateOfBirth = LocalDate.parse(dateOfBirthInput.getValue(), DateTimeFormatter.ofPattern("dd/MM/yyyy")),
-      ethnicity = Select(ethnicityDropdown).firstSelectedOption.text,
-      familyName = familyNameInput.getValue(),
-      firstNames = firstNamesInput.getValue(),
-      gender = Select(genderDropdown).firstSelectedOption.text,
-      immigrationStatus = Select(immigrationStatusDropdown).firstSelectedOption.text,
-      isInCustody = ualCheckbox.isSelected.not(),
-      nomsId = nomsIdInput.getValue(),
-      prisonerCategory = Select(prisonerCategoryDropdown).firstSelectedOption.text,
-      prisonNumber = prisonNumberInput.getValue(),
-      youngOffender = Select(youngOffenderDropdown).firstSelectedOption.text,
-      status = Select(statusDropdown).firstSelectedOption.text,
-      // Do sentences last because it navigates away
-      sentences = sentenceExtractor(determineSentenceLinks()),
-    )
-  }
+  fun extractOffenderDetails(sentenceExtractor: (List<String>) -> List<Sentence>): Offender = Offender(
+    id = extractOffenderId(),
+    address = extractAddress(),
+    caseworker = caseworkerInput.getValue(),
+    comments = commentsTextArea.getValue(),
+    croOtherNumber = croOtherNumberInput.getValue(),
+    dateOfBirth = LocalDate.parse(dateOfBirthInput.getValue(), DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+    ethnicity = Select(ethnicityDropdown).firstSelectedOption.text,
+    familyName = familyNameInput.getValue(),
+    firstNames = firstNamesInput.getValue(),
+    gender = Select(genderDropdown).firstSelectedOption.text,
+    immigrationStatus = Select(immigrationStatusDropdown).firstSelectedOption.text,
+    isInCustody = ualCheckbox.isSelected.not(),
+    nomsId = nomsIdInput.getValue(),
+    prisonerCategory = Select(prisonerCategoryDropdown).firstSelectedOption.text,
+    prisonNumber = prisonNumberInput.getValue(),
+    youngOffender = Select(youngOffenderDropdown).firstSelectedOption.text,
+    status = Select(statusDropdown).firstSelectedOption.text,
+    // Do sentences last because it navigates away
+    sentences = sentenceExtractor(determineSentenceLinks()),
+  )
 
   fun throwIfInvalid() {
     if (validationSummary?.text?.isNotBlank() == true) {
@@ -292,13 +288,11 @@ internal class OffenderPage(
     }
   }
 
-  private fun determineSentenceLinks(): List<String> {
-    return TreeView(navigationTreeViewRoot)
-      .expandNodeWithText("Sentences")
-      .children()
-      .filter { it.text.startsWith("New").not() }
-      .map { it.getAttribute("igurl") }
-  }
+  private fun determineSentenceLinks(): List<String> = TreeView(navigationTreeViewRoot)
+    .expandNodeWithText("Sentences")
+    .children()
+    .filter { it.text.startsWith("New").not() }
+    .map { it.getAttribute("igurl").orEmpty() }
 
   private fun extractOffenderId() = pageHelper.extractId("existing offender page")
 
@@ -335,14 +329,13 @@ internal class OffenderPage(
     return address
   }
 
-  private fun lastAddressRow(): WebElement =
-    if (addressHistoryLastPageLink != null) {
-      addressHistoryLastPageLink?.click()
-      viewAddressHistoryButton.click()
-      addressHistoryPagedLastRow
-    } else {
-      addressHistoryLastRow
-    }
+  private fun lastAddressRow(): WebElement = if (addressHistoryLastPageLink != null) {
+    addressHistoryLastPageLink?.click()
+    viewAddressHistoryButton.click()
+    addressHistoryPagedLastRow
+  } else {
+    addressHistoryLastRow
+  }
 
   private fun extractAddressFromRow(tableRow: WebElement): OffenderAddress {
     val cells = tableRow.findElements(By.xpath(addressHistoryTableCellsXpath))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/PostReleasePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/PostReleasePage.kt
@@ -92,25 +92,23 @@ internal class PostReleasePage(
     saveButton.click()
   }
 
-  fun extractPostReleaseDetails(): PostRelease {
-    return PostRelease(
-      assistantChiefOfficer = Contact(
-        name = assistantChiefOfficerInput.getValue(),
-        faxEmail = assistantChiefOfficerFaxEmailInput.getValue(),
-      ),
-      licenceType = Select(licenceTypeDropdown).firstSelectedOption.text,
-      offenderManager = ContactWithTelephone(
-        name = offenderManagerInput.getValue(),
-        faxEmail = offenderManagerFaxEmailInput.getValue(),
-        telephone = offenderManagerTelephoneInput.getValue(),
-      ),
-      probationService = Select(probationServiceDropdown).firstSelectedOption.text,
-      spoc = Contact(
-        name = spocInput.getValue(),
-        faxEmail = spocFaxEmailInput.getValue(),
-      ),
-    )
-  }
+  fun extractPostReleaseDetails(): PostRelease = PostRelease(
+    assistantChiefOfficer = Contact(
+      name = assistantChiefOfficerInput.getValue(),
+      faxEmail = assistantChiefOfficerFaxEmailInput.getValue(),
+    ),
+    licenceType = Select(licenceTypeDropdown).firstSelectedOption.text,
+    offenderManager = ContactWithTelephone(
+      name = offenderManagerInput.getValue(),
+      faxEmail = offenderManagerFaxEmailInput.getValue(),
+      telephone = offenderManagerTelephoneInput.getValue(),
+    ),
+    probationService = Select(probationServiceDropdown).firstSelectedOption.text,
+    spoc = Contact(
+      name = spocInput.getValue(),
+      faxEmail = spocFaxEmailInput.getValue(),
+    ),
+  )
 
   fun throwIfInvalid() {
     if (validationSummary?.text?.isNotBlank() == true) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/RecallPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/RecallPage.kt
@@ -210,10 +210,8 @@ internal class RecallPage(
     PageFactory.initElements(driver, this)
   }
 
-  fun isMatching(receivedDateTime: LocalDateTime, recommendedTo: PpudUser): Boolean {
-    return reportReceivedDateInput.getValue() == receivedDateTime.format(dateTimeFormatter) &&
-      recommendedToOwnerInput.getValue() == recommendedTo.fullName
-  }
+  fun isMatching(receivedDateTime: LocalDateTime, recommendedTo: PpudUser): Boolean = reportReceivedDateInput.getValue() == receivedDateTime.format(dateTimeFormatter) &&
+    recommendedToOwnerInput.getValue() == recommendedTo.fullName
 
   suspend fun createRecall(createRecallRequest: CreateRecallRequest) {
     // Complete these first as they trigger additional processing
@@ -304,9 +302,7 @@ internal class RecallPage(
     addMinuteInternal(contentCreator.generateRecallMinuteBackgroundInfoText(createRecallRequest))
   }
 
-  fun hasMatchingMinute(subject: String, text: String): Boolean {
-    return extractMinutes().stream().anyMatch { it.subject == subject && it.text == text }
-  }
+  fun hasMatchingMinute(subject: String, text: String): Boolean = extractMinutes().stream().anyMatch { it.subject == subject && it.text == text }
 
   fun addMinute(subject: String, text: String) {
     addMinuteInternal(subject = subject, text = text)
@@ -358,9 +354,7 @@ internal class RecallPage(
     )
   }
 
-  fun urlFor(id: String): String {
-    return urlPathTemplate.replace("{id}", id)
-  }
+  fun urlFor(id: String): String = urlPathTemplate.replace("{id}", id)
 
   private fun checkAllMissingMandatoryDocuments() {
     missingMandatoryDocumentsMap.forEach {
@@ -368,27 +362,23 @@ internal class RecallPage(
     }
   }
 
-  private fun extractMissingMandatoryDocuments(): List<DocumentCategory> {
-    return if (Select(mandatoryDocumentsReceivedDropdown).firstSelectedOption.text == "No") {
-      missingMandatoryDocumentsMap.mapNotNull { if (it.value.isSelected) it.key else null }
-    } else {
-      emptyList()
-    }
+  private fun extractMissingMandatoryDocuments(): List<DocumentCategory> = if (Select(mandatoryDocumentsReceivedDropdown).firstSelectedOption.text == "No") {
+    missingMandatoryDocumentsMap.mapNotNull { if (it.value.isSelected) it.key else null }
+  } else {
+    emptyList()
   }
 
-  private fun extractDocuments(): List<Document> {
-    return if (documentsTable != null) {
-      val rows = documentsTable!!.findElements(By.xpath(".//tr[position()>1]"))
-      rows.map {
-        Document(
-          title = it.findElement(By.xpath(".//td[3]")).text,
-          documentType = it.findElement(By.xpath(".//td[4]")).text,
-          owningCaseworker = it.findElement(By.xpath(".//td[12]")).text,
-        )
-      }
-    } else {
-      emptyList()
+  private fun extractDocuments(): List<Document> = if (documentsTable != null) {
+    val rows = documentsTable!!.findElements(By.xpath(".//tr[position()>1]"))
+    rows.map {
+      Document(
+        title = it.findElement(By.xpath(".//td[3]")).text,
+        documentType = it.findElement(By.xpath(".//td[4]")).text,
+        owningCaseworker = it.findElement(By.xpath(".//td[12]")).text,
+      )
     }
+  } else {
+    emptyList()
   }
 
   private fun extractMinutes(): List<Minute> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/ReleasePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/ReleasePage.kt
@@ -52,12 +52,10 @@ internal class ReleasePage(
     PageFactory.initElements(driver, this)
   }
 
-  fun isMatching(releasedFrom: String, releasedUnder: String): Boolean {
-    return (
-      releasedFrom == releasedFromInput.getValue() &&
-        releasedUnder == Select(releasedUnderDropdown).firstSelectedOption.text
-      )
-  }
+  fun isMatching(releasedFrom: String, releasedUnder: String): Boolean = (
+    releasedFrom == releasedFromInput.getValue() &&
+      releasedUnder == Select(releasedUnderDropdown).firstSelectedOption.text
+    )
 
   fun createRelease(createdOrUpdatedRelease: CreateOrUpdateReleaseRequest) {
     with(createdOrUpdatedRelease) {
@@ -83,9 +81,7 @@ internal class ReleasePage(
     saveButton.click()
   }
 
-  fun extractReleaseId(): String {
-    return pageHelper.extractId(pageDescription)
-  }
+  fun extractReleaseId(): String = pageHelper.extractId(pageDescription)
 
   fun throwIfInvalid() {
     if (validationSummary?.text?.isNotBlank() == true) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SearchPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SearchPage.kt
@@ -98,12 +98,10 @@ internal class SearchPage(private val driver: WebDriver) {
 
   fun searchResultsLinks(): List<String> {
     val resultsElements = resultsTable?.findElements(By.linkText("Select")) ?: emptyList<WebElement>()
-    return resultsElements.map { it.getAttribute("href") }
+    return resultsElements.map { it.getAttribute("href").orEmpty() }
   }
 
-  fun genderValues(): List<String> {
-    return Select(genderDropdown).options
-      .map { it.getValue() }
-      .filter { it.isNotBlank() }
-  }
+  fun genderValues(): List<String> = Select(genderDropdown).options
+    .map { it.getValue() }
+    .filter { it.isNotBlank() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentenceDeterminatePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentenceDeterminatePage.kt
@@ -115,11 +115,9 @@ internal class SentenceDeterminatePage(
     saveButton.click()
   }
 
-  override fun extractCreatedSentenceDetails(): CreatedSentence {
-    return CreatedSentence(
-      id = pageHelper.extractId(pageDescription),
-    )
-  }
+  override fun extractCreatedSentenceDetails(): CreatedSentence = CreatedSentence(
+    id = pageHelper.extractId(pageDescription),
+  )
 
   override fun extractSentenceDetails(
     offenceExtractor: (String) -> Offence,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentencePageFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentencePageFactory.kt
@@ -10,11 +10,9 @@ internal class SentencePageFactory(
   private val sentenceIndeterminatePage: SentenceIndeterminatePage,
 ) {
 
-  fun sentencePage(): SentencePage {
-    return if (driver.currentUrl.contains("SentenceIndeterminateDetails.aspx", ignoreCase = true)) {
-      sentenceIndeterminatePage
-    } else {
-      sentenceDeterminatePage
-    }
+  fun sentencePage(): SentencePage = if (driver.currentUrl.orEmpty().contains("SentenceIndeterminateDetails.aspx", ignoreCase = true)) {
+    sentenceIndeterminatePage
+  } else {
+    sentenceDeterminatePage
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/components/NavigationTreeViewComponent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/components/NavigationTreeViewComponent.kt
@@ -33,11 +33,9 @@ class NavigationTreeViewComponent(
     private const val URL_ATTRIBUTE = "igurl"
 
     val TreeViewNode.url: String
-      get() = this.getAttribute(URL_ATTRIBUTE)
+      get() = this.getAttribute(URL_ATTRIBUTE).orEmpty()
 
-    fun List<TreeViewNode>.excludeNewNode(): List<TreeViewNode> {
-      return this.filter { it.text != NEW_NODE_TEXT }
-    }
+    fun List<TreeViewNode>.excludeNewNode(): List<TreeViewNode> = this.filter { it.text != NEW_NODE_TEXT }
   }
 
   init {
@@ -62,18 +60,14 @@ class NavigationTreeViewComponent(
     return sentenceNode
   }
 
-  fun findOffenceNodeFor(sentenceId: String): TreeViewNode {
-    return findSentenceNodeFor(sentenceId)
-      .expandNode()
-      .findNodeWithText(OFFENCE_NODE_TEXT)
-  }
+  fun findOffenceNodeFor(sentenceId: String): TreeViewNode = findSentenceNodeFor(sentenceId)
+    .expandNode()
+    .findNodeWithText(OFFENCE_NODE_TEXT)
 
-  fun findReleaseNodesFor(sentenceId: String): List<TreeViewNode> {
-    return findSentenceNodeFor(sentenceId)
-      .expandNode()
-      .expandNodeWithText(RELEASES_NODE_TEXT)
-      .children()
-  }
+  fun findReleaseNodesFor(sentenceId: String): List<TreeViewNode> = findSentenceNodeFor(sentenceId)
+    .expandNode()
+    .expandNodeWithText(RELEASES_NODE_TEXT)
+    .children()
 
   fun findReleaseNodeFor(releaseId: String): TreeViewNode {
     val releaseNodes = sentenceNodes
@@ -96,23 +90,17 @@ class NavigationTreeViewComponent(
     return matchingRelease
   }
 
-  fun findPostReleaseNodeFor(releaseId: String): TreeViewNode {
-    return findReleaseNodeFor(releaseId)
-      .expandNode()
-      .findNodeWithTextContaining(POST_RELEASE_NODE_TEXT)
-  }
+  fun findPostReleaseNodeFor(releaseId: String): TreeViewNode = findReleaseNodeFor(releaseId)
+    .expandNode()
+    .findNodeWithTextContaining(POST_RELEASE_NODE_TEXT)
 
-  fun findRecallNodesFor(releaseId: String): List<TreeViewNode> {
-    return findReleaseNodeFor(releaseId)
-      .expandNode()
-      .expandNodeWithTextContaining(RECALLS_NODE_TEXT)
-      .children()
-  }
+  fun findRecallNodesFor(releaseId: String): List<TreeViewNode> = findReleaseNodeFor(releaseId)
+    .expandNode()
+    .expandNodeWithTextContaining(RECALLS_NODE_TEXT)
+    .children()
 
-  fun findRecallsNodeFor(releaseId: String): TreeViewNode {
-    return findReleaseNodeFor(releaseId)
-      .expandNodeWithTextContaining(RECALLS_NODE_TEXT)
-  }
+  fun findRecallsNodeFor(releaseId: String): TreeViewNode = findReleaseNodeFor(releaseId)
+    .expandNodeWithTextContaining(RECALLS_NODE_TEXT)
 
   fun navigateToNewSentence() {
     TreeView(navigationTreeViewRoot)
@@ -141,11 +129,9 @@ class NavigationTreeViewComponent(
     resultNode.click()
   }
 
-  fun navigateToNewRecallFor(releaseId: String) {
-    return findRecallsNodeFor(releaseId)
-      .findNodeWithText(NEW_NODE_TEXT)
-      .click()
-  }
+  fun navigateToNewRecallFor(releaseId: String) = findRecallsNodeFor(releaseId)
+    .findNodeWithText(NEW_NODE_TEXT)
+    .click()
 
   fun extractSentenceLinks(dateOfSentence: LocalDate, custodyType: String): List<String> {
     val formattedDate = dateOfSentence.format(dateFormatter)
@@ -154,24 +140,18 @@ class NavigationTreeViewComponent(
       .map { it.url }
   }
 
-  fun extractReleaseLinks(sentenceId: String, includeEmptyReleases: Boolean): List<String> {
-    return findReleaseNodesFor(sentenceId)
-      .filter {
-        it.text.startsWith(NEW_NODE_TEXT).not() &&
-          (includeEmptyReleases || it.text.trim().startsWith(NOT_SPECIFIED_TEXT).not())
-      }
-      .map { it.url }
-  }
+  fun extractReleaseLinks(sentenceId: String, includeEmptyReleases: Boolean): List<String> = findReleaseNodesFor(sentenceId)
+    .filter {
+      it.text.startsWith(NEW_NODE_TEXT).not() &&
+        (includeEmptyReleases || it.text.trim().startsWith(NOT_SPECIFIED_TEXT).not())
+    }
+    .map { it.url }
 
-  fun extractReleaseLinks(sentenceId: String, dateOfRelease: LocalDate): List<String> {
-    return findReleaseNodesFor(sentenceId)
-      .filter { it.text.contains(dateOfRelease.format(dateFormatter)) }
-      .map { it.url }
-  }
+  fun extractReleaseLinks(sentenceId: String, dateOfRelease: LocalDate): List<String> = findReleaseNodesFor(sentenceId)
+    .filter { it.text.contains(dateOfRelease.format(dateFormatter)) }
+    .map { it.url }
 
-  fun extractRecallLinks(releaseId: String): List<String> {
-    return findRecallNodesFor(releaseId)
-      .excludeNewNode()
-      .map { it.url }
-  }
+  fun extractRecallLinks(releaseId: String): List<String> = findRecallNodesFor(releaseId)
+    .excludeNewNode()
+    .map { it.url }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/helpers/PageHelper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/helpers/PageHelper.kt
@@ -18,9 +18,7 @@ class PageHelper(
 ) {
 
   companion object {
-    fun WebElement.getValue(): String {
-      return this.getAttribute("value")?.trim() ?: ""
-    }
+    fun WebElement.getValue(): String = this.getAttribute("value")?.trim() ?: ""
   }
 
   fun dismissConfirmDeleteAlert() {
@@ -73,21 +71,17 @@ class PageHelper(
   }
 
   fun extractId(pageDescription: String): String {
-    val url = driver.currentUrl
+    val url = driver.currentUrl.orEmpty()
     val idMatch = Regex(".+?data=(.+)").find(url)
       ?: throw AutomationException("Expected the $pageDescription but URL was '$url'")
     val (id) = idMatch.destructured
     return id
   }
 
-  fun isCustomErrorUrl(): Boolean {
-    return driver.currentUrl.contains("CustomErrors/Error.aspx", ignoreCase = true)
-  }
+  fun isCustomErrorUrl(): Boolean = driver.currentUrl.orEmpty().contains("CustomErrors/Error.aspx", ignoreCase = true)
 
-  fun readDate(input: WebElement): LocalDate {
-    return readDateOrNull(input)
-      ?: throw AutomationException("Expected valid date in element but value was '${input.getValue()}'")
-  }
+  fun readDate(input: WebElement): LocalDate = readDateOrNull(input)
+    ?: throw AutomationException("Expected valid date in element but value was '${input.getValue()}'")
 
   fun readDateOrNull(input: WebElement): LocalDate? {
     val inputValue = input.getValue()
@@ -103,9 +97,7 @@ class PageHelper(
     return inputValue.toIntOrNull() ?: default
   }
 
-  fun readSelectedOption(dropdown: WebElement): String {
-    return Select(dropdown).firstSelectedOption.text
-  }
+  fun readSelectedOption(dropdown: WebElement): String = Select(dropdown).firstSelectedOption.text
 
   fun selectDropdownOptionIfNotBlank(dropdown: WebElement, option: String?, description: String) {
     if (option?.isNotBlank() == true) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/selenium/TreeView.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/selenium/TreeView.kt
@@ -8,14 +8,10 @@ class TreeView(rootElement: WebElement) {
   private val nodes =
     rootElement.findElements(By.xpath("./div"))
       .filter {
-        it.getAttribute("id").startsWith("M_").not()
+        it.getAttribute("id").orEmpty().startsWith("M_").not()
       }
 
-  fun expandNodeWithText(text: String): TreeViewNode {
-    return TreeViewNode(nodes.first { it.text.trim() == text }).expandNode()
-  }
+  fun expandNodeWithText(text: String): TreeViewNode = TreeViewNode(nodes.first { it.text.trim() == text }).expandNode()
 
-  fun children(): List<TreeViewNode> {
-    return nodes.map { TreeViewNode(it) }
-  }
+  fun children(): List<TreeViewNode> = nodes.map { TreeViewNode(it) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/selenium/TreeViewNode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/selenium/TreeViewNode.kt
@@ -9,7 +9,7 @@ import org.openqa.selenium.WebElement
 
 private val WebElement.isExpansionElement: Boolean
   get() {
-    return this.getAttribute("id").startsWith("M_")
+    return this.getAttribute("id").orEmpty().startsWith("M_")
   }
 
 open class TreeViewNode(private val element: WebElement) : WebElement {
@@ -20,11 +20,9 @@ open class TreeViewNode(private val element: WebElement) : WebElement {
 
   private val nodeTextElement by lazy { findElement(By.xpath("./span[@igtxt='1']")) }
 
-  fun children(): List<TreeViewNode> {
-    return expansionElement.findElements(By.xpath("./div"))
-      .filter { !it.isExpansionElement }
-      .map { TreeViewNode(it) }
-  }
+  fun children(): List<TreeViewNode> = expansionElement.findElements(By.xpath("./div"))
+    .filter { !it.isExpansionElement }
+    .map { TreeViewNode(it) }
 
   fun expandNode(): TreeViewNode {
     if (expansionElement.isDisplayed.not()) {
@@ -33,48 +31,30 @@ open class TreeViewNode(private val element: WebElement) : WebElement {
     return this
   }
 
-  fun expandNodeWithText(text: String): TreeViewNode {
-    return findNodeWithText(text).expandNode()
-  }
+  fun expandNodeWithText(text: String): TreeViewNode = findNodeWithText(text).expandNode()
 
-  fun expandNodeWithTextContaining(text: String): TreeViewNode {
-    return findNodeWithTextContaining(text).expandNode()
-  }
+  fun expandNodeWithTextContaining(text: String): TreeViewNode = findNodeWithTextContaining(text).expandNode()
 
-  fun expandNodeWithLinkContaining(value: String): TreeViewNode {
-    return findNodeWithLinkContaining(value).expandNode()
-  }
+  fun expandNodeWithLinkContaining(value: String): TreeViewNode = findNodeWithLinkContaining(value).expandNode()
 
-  fun findNodeWithTextContaining(text: String): TreeViewNode {
-    return TreeViewNode(expansionElement.findElement(By.xpath(xpathForNodeWithTextContaining(text))))
-  }
+  fun findNodeWithTextContaining(text: String): TreeViewNode = TreeViewNode(expansionElement.findElement(By.xpath(xpathForNodeWithTextContaining(text))))
 
-  fun findNodeWithText(text: String): TreeViewNode {
-    return TreeViewNode(expansionElement.findElement(By.xpath(".//*[text()='$text']/parent::div")))
-  }
+  fun findNodeWithText(text: String): TreeViewNode = TreeViewNode(expansionElement.findElement(By.xpath(".//*[text()='$text']/parent::div")))
 
   fun tryFindNodeWithTextContaining(text: String): TreeViewNode? {
     val matches = expansionElement.findElements(By.xpath(xpathForNodeWithTextContaining(text)))
     return if (matches.any()) TreeViewNode(matches.first()) else null
   }
 
-  private fun findNodeWithLinkContaining(value: String): TreeViewNode {
-    return TreeViewNode(expansionElement.findElement(By.xpath(".//div[contains(@igurl, '$value')]")))
-  }
+  private fun findNodeWithLinkContaining(value: String): TreeViewNode = TreeViewNode(expansionElement.findElement(By.xpath(".//div[contains(@igurl, '$value')]")))
 
   private fun xpathForNodeWithTextContaining(text: String) = ".//*[contains(text(), '$text')]/parent::div"
 
-  override fun findElements(by: By?): MutableList<WebElement> {
-    return element.findElements(by)
-  }
+  override fun findElements(by: By): MutableList<WebElement> = element.findElements(by)
 
-  override fun findElement(by: By?): WebElement {
-    return element.findElement(by)
-  }
+  override fun findElement(by: By): WebElement = element.findElement(by)
 
-  override fun <X : Any?> getScreenshotAs(target: OutputType<X>?): X {
-    return element.getScreenshotAs(target)
-  }
+  override fun <X : Any> getScreenshotAs(target: OutputType<X>): X = element.getScreenshotAs(target)
 
   override fun click() {
     nodeTextElement.click()
@@ -84,7 +64,7 @@ open class TreeViewNode(private val element: WebElement) : WebElement {
     element.submit()
   }
 
-  override fun sendKeys(vararg keysToSend: CharSequence?) {
+  override fun sendKeys(vararg keysToSend: CharSequence) {
     element.sendKeys()
   }
 
@@ -92,43 +72,23 @@ open class TreeViewNode(private val element: WebElement) : WebElement {
     element.clear()
   }
 
-  override fun getTagName(): String {
-    return element.tagName
-  }
+  override fun getTagName(): String = element.tagName
 
-  override fun getAttribute(name: String?): String {
-    return element.getAttribute(name)
-  }
+  override fun getAttribute(name: String): String = element.getAttribute(name).orEmpty()
 
-  override fun isSelected(): Boolean {
-    return element.isSelected
-  }
+  override fun isSelected(): Boolean = element.isSelected
 
-  override fun isEnabled(): Boolean {
-    return element.isEnabled
-  }
+  override fun isEnabled(): Boolean = element.isEnabled
 
-  override fun getText(): String {
-    return element.text
-  }
+  override fun getText(): String = element.text
 
-  override fun isDisplayed(): Boolean {
-    return element.isDisplayed
-  }
+  override fun isDisplayed(): Boolean = element.isDisplayed
 
-  override fun getLocation(): Point {
-    return element.location
-  }
+  override fun getLocation(): Point = element.location
 
-  override fun getSize(): Dimension {
-    return element.size
-  }
+  override fun getSize(): Dimension = element.size
 
-  override fun getRect(): Rectangle {
-    return element.rect
-  }
+  override fun getRect(): Rectangle = element.rect
 
-  override fun getCssValue(propertyName: String?): String {
-    return element.getCssValue(propertyName)
-  }
+  override fun getCssValue(propertyName: String): String = element.getCssValue(propertyName).orEmpty()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/ReferenceServiceImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/ReferenceServiceImpl.kt
@@ -41,49 +41,31 @@ internal class ReferenceServiceImpl(
   }
 
   @Cacheable(CUSTODY_TYPES_CACHE_NAME)
-  override suspend fun retrieveCustodyTypes(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.CustodyTypes)
-  }
+  override suspend fun retrieveCustodyTypes(): List<String> = ppudClient.retrieveLookupValues(LookupName.CustodyTypes)
 
   @Cacheable(ESTABLISHMENTS_CACHE_NAME)
-  override suspend fun retrieveEstablishments(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.Establishments)
-  }
+  override suspend fun retrieveEstablishments(): List<String> = ppudClient.retrieveLookupValues(LookupName.Establishments)
 
   @Cacheable(ETHNICITIES_CACHE_NAME)
-  override suspend fun retrieveEthnicities(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.Ethnicities)
-  }
+  override suspend fun retrieveEthnicities(): List<String> = ppudClient.retrieveLookupValues(LookupName.Ethnicities)
 
   @Cacheable(GENDERS_CACHE_NAME)
-  override suspend fun retrieveGenders(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.Genders)
-  }
+  override suspend fun retrieveGenders(): List<String> = ppudClient.retrieveLookupValues(LookupName.Genders)
 
   @Cacheable(INDEX_OFFENCES_CACHE_NAME)
-  override suspend fun retrieveIndexOffences(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.IndexOffences)
-  }
+  override suspend fun retrieveIndexOffences(): List<String> = ppudClient.retrieveLookupValues(LookupName.IndexOffences)
 
   @Cacheable(MAPPA_LEVELS_CACHE_NAME)
-  override suspend fun retrieveMappaLevels(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.MappaLevels)
-  }
+  override suspend fun retrieveMappaLevels(): List<String> = ppudClient.retrieveLookupValues(LookupName.MappaLevels)
 
   @Cacheable(POLICE_FORCES_CACHE_NAME)
-  override suspend fun retrievePoliceForces(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.PoliceForces)
-  }
+  override suspend fun retrievePoliceForces(): List<String> = ppudClient.retrieveLookupValues(LookupName.PoliceForces)
 
   @Cacheable(PROBATION_SERVICES_CACHE_NAME)
-  override suspend fun retrieveProbationServices(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.ProbationServices)
-  }
+  override suspend fun retrieveProbationServices(): List<String> = ppudClient.retrieveLookupValues(LookupName.ProbationServices)
 
   @Cacheable(RELEASED_UNDERS_CACHE_NAME)
-  override suspend fun retrieveReleasedUnders(): List<String> {
-    return ppudClient.retrieveLookupValues(LookupName.ReleasedUnders)
-  }
+  override suspend fun retrieveReleasedUnders(): List<String> = ppudClient.retrieveLookupValues(LookupName.ReleasedUnders)
 
   override fun quit() {
     ppudClient.quit()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/util/YoungOffenderCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/util/YoungOffenderCalculator.kt
@@ -8,7 +8,5 @@ internal class YoungOffenderCalculator(private val currentDate: CurrentDate) {
 
   private val youngOffenderAgeLimit: Long = 21
 
-  fun isYoungOffender(dateOfBirth: LocalDate): Boolean {
-    return currentDate.now() < dateOfBirth.plusYears(youngOffenderAgeLimit)
-  }
+  fun isYoungOffender(dateOfBirth: LocalDate): Boolean = currentDate.now() < dateOfBirth.plusYears(youngOffenderAgeLimit)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparatorTest.kt
@@ -25,19 +25,17 @@ internal class SentenceComparatorTest {
      *  These are the key fields on which we base a match.
      */
     @JvmStatic
-    fun keyFieldsSource(): Stream<String> {
-      return Stream.of(
-        "custodyType",
-        "dateOfSentence",
-        "licenceExpiryDate",
-        "mappaLevel",
-        "sentenceExpiryDate",
-        "sentenceLength.partYears",
-        "sentenceLength.partMonths",
-        "sentenceLength.partDays",
-        "sentencingCourt",
-      )
-    }
+    fun keyFieldsSource(): Stream<String> = Stream.of(
+      "custodyType",
+      "dateOfSentence",
+      "licenceExpiryDate",
+      "mappaLevel",
+      "sentenceExpiryDate",
+      "sentenceLength.partYears",
+      "sentenceLength.partMonths",
+      "sentenceLength.partDays",
+      "sentencingCourt",
+    )
   }
 
   @BeforeEach
@@ -152,12 +150,9 @@ internal class SentenceComparatorTest {
     assertFalse(result)
   }
 
-  private fun differsOrTheSame(keyFieldToBeDifferent: String, fieldName: String, value: String): String =
-    if (keyFieldToBeDifferent == fieldName) "differs" else value
+  private fun differsOrTheSame(keyFieldToBeDifferent: String, fieldName: String, value: String): String = if (keyFieldToBeDifferent == fieldName) "differs" else value
 
-  private fun differsOrTheSame(keyFieldToBeDifferent: String, fieldName: String, value: LocalDate): LocalDate =
-    if (keyFieldToBeDifferent == fieldName) value.plusDays(1) else value
+  private fun differsOrTheSame(keyFieldToBeDifferent: String, fieldName: String, value: LocalDate): LocalDate = if (keyFieldToBeDifferent == fieldName) value.plusDays(1) else value
 
-  private fun differsOrTheSame(keyFieldToBeDifferent: String, fieldName: String, value: Int): Int =
-    if (keyFieldToBeDifferent == fieldName) value - 1 else value
+  private fun differsOrTheSame(keyFieldToBeDifferent: String, fieldName: String, value: Int): Int = if (keyFieldToBeDifferent == fieldName) value - 1 else value
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PpudHealthTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PpudHealthTest.kt
@@ -98,9 +98,7 @@ class PpudHealthTest {
       .build()
   }
 
-  private fun createResponseBody(responsePageTitle: String, text: String): String {
-    return "<html><head><title>$responsePageTitle</title></head><body>$text</body></html>"
-  }
+  private fun createResponseBody(responsePageTitle: String, text: String): String = "<html><head><title>$responsePageTitle</title></head><body>$text</body></html>"
 
   private fun setupMockToRespondWith(statusCode: HttpStatusCode, responseBody: String) {
     ppudMock

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/Extensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/Extensions.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.helpers
 
 import java.time.LocalDateTime
 
-fun LocalDateTime.withoutSeconds(): String {
-  return this
-    .truncatedTo(java.time.temporal.ChronoUnit.MINUTES)
-    .format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-}
+fun LocalDateTime.withoutSeconds(): String = this
+  .truncatedTo(java.time.temporal.ChronoUnit.MINUTES)
+  .format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/IsSameDayAs.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/IsSameDayAs.kt
@@ -14,6 +14,4 @@ class IsSameDayAs(private val thisDate: LocalDate, private val message: String) 
   }
 }
 
-fun isSameDayAs(date: LocalDate, message: String): IsSameDayAs {
-  return IsSameDayAs(date, message)
-}
+fun isSameDayAs(date: LocalDate, message: String): IsSameDayAs = IsSameDayAs(date, message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/JwtAuthHelper.kt
@@ -32,20 +32,19 @@ class JwtAuthHelper {
     expiryTime: Duration = Duration.ofHours(1),
     jwtId: String = UUID.randomUUID().toString(),
     clientId: String = "hmpps-ppud-automation-api",
-  ): String =
-    mutableMapOf<String, Any>()
-      .also { subject?.let { subject -> it["user_name"] = subject } }
-      .also { it["client_id"] = clientId }
-      .also { subject?.let { subject -> it["name"] = subject.lowercase() } }
-      .also { roles?.let { roles -> it["authorities"] = roles } }
-      .also { scope?.let { scope -> it["scope"] = scope } }
-      .let {
-        Jwts.builder()
-          .id(jwtId)
-          .subject(subject)
-          .claims(it.toMap())
-          .expiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
-          .signWith(keyPair.private, Jwts.SIG.RS256)
-          .compact()
-      }
+  ): String = mutableMapOf<String, Any>()
+    .also { subject?.let { subject -> it["user_name"] = subject } }
+    .also { it["client_id"] = clientId }
+    .also { subject?.let { subject -> it["name"] = subject.lowercase() } }
+    .also { roles?.let { roles -> it["authorities"] = roles } }
+    .also { scope?.let { scope -> it["scope"] = scope } }
+    .let {
+      Jwts.builder()
+        .id(jwtId)
+        .subject(subject)
+        .claims(it.toMap())
+        .expiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
+        .signWith(keyPair.private, Jwts.SIG.RS256)
+        .compact()
+    }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/ValueDoesNotContainConsumer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/ValueDoesNotContainConsumer.kt
@@ -12,6 +12,4 @@ class ValueDoesNotContainConsumer(private val element: String) : Consumer<JSONAr
   }
 }
 
-fun doesNotContain(element: String): Consumer<JSONArray> {
-  return ValueDoesNotContainConsumer(element)
-}
+fun doesNotContain(element: String): Consumer<JSONArray> = ValueDoesNotContainConsumer(element)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/ValueIsNullConsumer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/ValueIsNullConsumer.kt
@@ -11,6 +11,4 @@ class ValueIsNullConsumer<T> : Consumer<T> {
   }
 }
 
-fun isNull(): Consumer<String> {
-  return ValueIsNullConsumer()
-}
+fun isNull(): Consumer<String> = ValueIsNullConsumer()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -83,25 +83,23 @@ abstract class IntegrationTestBase {
       mappaLevel: String = PPUD_VALID_MAPPA_LEVEL,
       nomsId: String = "",
       prisonNumber: String = randomPrisonNumber(),
-    ): String {
-      return "{" +
-        "\"address\":$address, " +
-        "\"additionalAddresses\":[$additionalAddresses], " +
-        "\"croNumber\":\"$croNumber\", " +
-        "\"custodyType\":\"$custodyType\", " +
-        "\"dateOfBirth\":\"$dateOfBirth\", " +
-        "\"dateOfSentence\":\"$dateOfSentence\", " +
-        "\"ethnicity\":\"$ethnicity\", " +
-        "\"familyName\":\"$familyName\", " +
-        "\"firstNames\":\"$firstNames\", " +
-        "\"gender\":\"$gender\", " +
-        "\"indexOffence\":\"$indexOffence\", " +
-        "\"isInCustody\":\"$isInCustody\", " +
-        "\"mappaLevel\":\"$mappaLevel\", " +
-        "\"nomsId\":\"$nomsId\", " +
-        "\"prisonNumber\":\"$prisonNumber\" " +
-        "}"
-    }
+    ): String = "{" +
+      "\"address\":$address, " +
+      "\"additionalAddresses\":[$additionalAddresses], " +
+      "\"croNumber\":\"$croNumber\", " +
+      "\"custodyType\":\"$custodyType\", " +
+      "\"dateOfBirth\":\"$dateOfBirth\", " +
+      "\"dateOfSentence\":\"$dateOfSentence\", " +
+      "\"ethnicity\":\"$ethnicity\", " +
+      "\"familyName\":\"$familyName\", " +
+      "\"firstNames\":\"$firstNames\", " +
+      "\"gender\":\"$gender\", " +
+      "\"indexOffence\":\"$indexOffence\", " +
+      "\"isInCustody\":\"$isInCustody\", " +
+      "\"mappaLevel\":\"$mappaLevel\", " +
+      "\"nomsId\":\"$nomsId\", " +
+      "\"prisonNumber\":\"$prisonNumber\" " +
+      "}"
 
     fun updateOffenderRequestBody(
       address: String = addressRequestBody(),
@@ -115,21 +113,19 @@ abstract class IntegrationTestBase {
       isInCustody: String = "false",
       nomsId: String = "",
       prisonNumber: String = randomPrisonNumber(),
-    ): String {
-      return "{" +
-        "\"address\":$address, " +
-        "\"additionalAddresses\":[$additionalAddresses], " +
-        "\"croNumber\":\"$croNumber\", " +
-        "\"dateOfBirth\":\"$dateOfBirth\", " +
-        "\"ethnicity\":\"$ethnicity\", " +
-        "\"familyName\":\"$familyName\", " +
-        "\"firstNames\":\"$firstNames\", " +
-        "\"gender\":\"$gender\", " +
-        "\"isInCustody\":\"$isInCustody\", " +
-        "\"nomsId\":\"$nomsId\", " +
-        "\"prisonNumber\":\"$prisonNumber\" " +
-        "}"
-    }
+    ): String = "{" +
+      "\"address\":$address, " +
+      "\"additionalAddresses\":[$additionalAddresses], " +
+      "\"croNumber\":\"$croNumber\", " +
+      "\"dateOfBirth\":\"$dateOfBirth\", " +
+      "\"ethnicity\":\"$ethnicity\", " +
+      "\"familyName\":\"$familyName\", " +
+      "\"firstNames\":\"$firstNames\", " +
+      "\"gender\":\"$gender\", " +
+      "\"isInCustody\":\"$isInCustody\", " +
+      "\"nomsId\":\"$nomsId\", " +
+      "\"prisonNumber\":\"$prisonNumber\" " +
+      "}"
 
     fun createOrUpdateSentenceRequestBody(
       custodyType: String = PPUD_VALID_CUSTODY_TYPE,
@@ -146,44 +142,40 @@ abstract class IntegrationTestBase {
       sentenceLengthPartMonths: Int = Random.nextInt(0, 20),
       sentenceLengthPartDays: Int = Random.nextInt(0, 20),
       sentencingCourt: String = randomString("sentCourt"),
-    ): String {
-      return "{" +
-        "\"custodyType\":\"$custodyType\", " +
-        "\"dateOfSentence\":\"$dateOfSentence\", " +
-        "\"espCustodialPeriod\":{" +
-        "  \"years\":\"$espCustodialPeriodYears\", " +
-        "  \"months\":\"$espCustodialPeriodMonths\" " +
-        "}," +
-        "\"espExtendedPeriod\":{" +
-        "  \"years\":\"$espExtendedPeriodYears\", " +
-        "  \"months\":\"$espExtendedPeriodMonths\" " +
-        "}," +
-        "\"licenceExpiryDate\":\"$licenceExpiryDate\", " +
-        "\"mappaLevel\":\"$mappaLevel\", " +
-        "\"releaseDate\":\"$releaseDate\", " +
-        "\"sentenceExpiryDate\":\"$sentenceExpiryDate\", " +
-        "\"sentenceLength\":{" +
-        "  \"partYears\":\"$sentenceLengthPartYears\", " +
-        "  \"partMonths\":\"$sentenceLengthPartMonths\", " +
-        "  \"partDays\":\"$sentenceLengthPartDays\" " +
-        "}," +
-        "\"sentencingCourt\":\"$sentencingCourt\" " +
-        "}"
-    }
+    ): String = "{" +
+      "\"custodyType\":\"$custodyType\", " +
+      "\"dateOfSentence\":\"$dateOfSentence\", " +
+      "\"espCustodialPeriod\":{" +
+      "  \"years\":\"$espCustodialPeriodYears\", " +
+      "  \"months\":\"$espCustodialPeriodMonths\" " +
+      "}," +
+      "\"espExtendedPeriod\":{" +
+      "  \"years\":\"$espExtendedPeriodYears\", " +
+      "  \"months\":\"$espExtendedPeriodMonths\" " +
+      "}," +
+      "\"licenceExpiryDate\":\"$licenceExpiryDate\", " +
+      "\"mappaLevel\":\"$mappaLevel\", " +
+      "\"releaseDate\":\"$releaseDate\", " +
+      "\"sentenceExpiryDate\":\"$sentenceExpiryDate\", " +
+      "\"sentenceLength\":{" +
+      "  \"partYears\":\"$sentenceLengthPartYears\", " +
+      "  \"partMonths\":\"$sentenceLengthPartMonths\", " +
+      "  \"partDays\":\"$sentenceLengthPartDays\" " +
+      "}," +
+      "\"sentencingCourt\":\"$sentencingCourt\" " +
+      "}"
 
     fun releaseRequestBody(
       dateOfRelease: String = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE),
       postRelease: String = postReleaseRequestBody(),
       releasedFrom: String = PPUD_VALID_RELEASED_FROM,
       releasedUnder: String = PPUD_VALID_RELEASED_UNDER,
-    ): String {
-      return "{" +
-        "\"dateOfRelease\":\"$dateOfRelease\", " +
-        "\"postRelease\":$postRelease, " +
-        "\"releasedFrom\":\"$releasedFrom\", " +
-        "\"releasedUnder\":\"$releasedUnder\" " +
-        "}"
-    }
+    ): String = "{" +
+      "\"dateOfRelease\":\"$dateOfRelease\", " +
+      "\"postRelease\":$postRelease, " +
+      "\"releasedFrom\":\"$releasedFrom\", " +
+      "\"releasedUnder\":\"$releasedUnder\" " +
+      "}"
 
     fun postReleaseRequestBody(
       assistantChiefOfficerName: String = randomString("acoName"),
@@ -194,24 +186,22 @@ abstract class IntegrationTestBase {
       probationService: String = PPUD_VALID_PROBATION_SERVICE,
       spocName: String = randomString("spocName"),
       spocFaxEmail: String = randomString("spocFaxEmail"),
-    ): String {
-      return "{" +
-        "\"assistantChiefOfficer\":{" +
-        "  \"name\":\"$assistantChiefOfficerName\", " +
-        "  \"faxEmail\":\"$assistantChiefOfficerFaxEmail\" " +
-        "}," +
-        "\"offenderManager\":{" +
-        "  \"name\":\"$offenderManagerName\", " +
-        "  \"faxEmail\":\"$offenderManagerFaxEmail\", " +
-        "  \"telephone\":\"$offenderManagerTelephone\" " +
-        "}," +
-        "\"probationService\":\"$probationService\", " +
-        "\"spoc\":{" +
-        "  \"name\":\"$spocName\", " +
-        "  \"faxEmail\":\"$spocFaxEmail\" " +
-        "}" +
-        "}"
-    }
+    ): String = "{" +
+      "\"assistantChiefOfficer\":{" +
+      "  \"name\":\"$assistantChiefOfficerName\", " +
+      "  \"faxEmail\":\"$assistantChiefOfficerFaxEmail\" " +
+      "}," +
+      "\"offenderManager\":{" +
+      "  \"name\":\"$offenderManagerName\", " +
+      "  \"faxEmail\":\"$offenderManagerFaxEmail\", " +
+      "  \"telephone\":\"$offenderManagerTelephone\" " +
+      "}," +
+      "\"probationService\":\"$probationService\", " +
+      "\"spoc\":{" +
+      "  \"name\":\"$spocName\", " +
+      "  \"faxEmail\":\"$spocFaxEmail\" " +
+      "}" +
+      "}"
 
     fun createRecallRequestBody(
       decisionDateTime: String = randomDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
@@ -224,8 +214,7 @@ abstract class IntegrationTestBase {
       recommendedTo: String? = ppudUserRequestBody(),
       riskOfContrabandDetails: String = "",
       riskOfSeriousHarmLevel: String = RiskOfSeriousHarmLevel.VeryHigh.name,
-    ): String {
-      return """
+    ): String = """
         {
           "decisionDateTime":"$decisionDateTime",
           "isInCustody":"$isInCustody",
@@ -238,20 +227,17 @@ abstract class IntegrationTestBase {
           "riskOfContrabandDetails":"$riskOfContrabandDetails",
           "riskOfSeriousHarmLevel":"$riskOfSeriousHarmLevel"
         }
-      """.trimIndent()
-    }
+    """.trimIndent()
 
     fun ppudUserRequestBody(
       fullName: String = PPUD_VALID_USER_FULL_NAME,
       teamName: String = PPUD_VALID_USER_TEAM,
-    ): String {
-      return """
+    ): String = """
         {
           "fullName":"$fullName",
           "teamName":"$teamName"
         }
-      """.trimIndent()
-    }
+    """.trimIndent()
 
     fun addressRequestBody(
       premises: String = randomString("premises"),
@@ -259,15 +245,13 @@ abstract class IntegrationTestBase {
       line2: String = randomString("line2"),
       postcode: String = randomString("postcode"),
       phoneNumber: String = randomString("phoneNumber"),
-    ): String {
-      return "{" +
-        "\"premises\":\"$premises\", " +
-        "\"line1\":\"$line1\", " +
-        "\"line2\":\"$line2\", " +
-        "\"postcode\":\"$postcode\", " +
-        "\"phoneNumber\":\"$phoneNumber\" " +
-        "}"
-    }
+    ): String = "{" +
+      "\"premises\":\"$premises\", " +
+      "\"line1\":\"$line1\", " +
+      "\"line2\":\"$line2\", " +
+      "\"postcode\":\"$postcode\", " +
+      "\"phoneNumber\":\"$phoneNumber\" " +
+      "}"
   }
 
   @BeforeAll
@@ -384,41 +368,34 @@ abstract class IntegrationTestBase {
       .isOk
   }
 
-  protected fun putOffender(offenderId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.put()
-      .uri("/offender/$offenderId")
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  protected fun putOffender(offenderId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.put()
+    .uri("/offender/$offenderId")
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
-  protected fun retrieveOffender(id: String): WebTestClient.BodyContentSpec {
-    return webTestClient.get()
-      .uri("/offender/$id")
-      .headers { it.authToken() }
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-  }
+  protected fun retrieveOffender(id: String): WebTestClient.BodyContentSpec = webTestClient.get()
+    .uri("/offender/$id")
+    .headers { it.authToken() }
+    .accept(MediaType.APPLICATION_JSON)
+    .exchange()
+    .expectStatus().isOk
+    .expectBody()
 
-  protected fun retrieveOffenderWhenNotOk(id: String): WebTestClient.ResponseSpec {
-    return webTestClient.get()
-      .uri("/offender/$id")
-      .headers { it.authToken() }
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-  }
+  protected fun retrieveOffenderWhenNotOk(id: String): WebTestClient.ResponseSpec = webTestClient.get()
+    .uri("/offender/$id")
+    .headers { it.authToken() }
+    .accept(MediaType.APPLICATION_JSON)
+    .exchange()
 
-  protected fun retrieveRecall(id: String): WebTestClient.BodyContentSpec {
-    return webTestClient.get()
-      .uri("/recall/$id")
-      .headers { it.authToken() }
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-  }
+  protected fun retrieveRecall(id: String): WebTestClient.BodyContentSpec = webTestClient.get()
+    .uri("/recall/$id")
+    .headers { it.authToken() }
+    .accept(MediaType.APPLICATION_JSON)
+    .exchange()
+    .expectStatus().isOk
+    .expectBody()
 
   protected fun givenMissingTokenWhenCalledThenUnauthorizedReturned(method: HttpMethod, uri: String) {
     webTestClient.method(method)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -143,8 +143,7 @@ abstract class IntegrationTestBase {
       sentenceLengthPartDays: Int = Random.nextInt(0, 20),
       sentencingCourt: String = randomString("sentCourt"),
       sentencedUnder: String = randomString(),
-    ) =
-      """ 
+    ) = """ 
         {
           "custodyType":"$custodyType",
           "dateOfSentence":"$dateOfSentence",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -167,7 +167,7 @@ abstract class IntegrationTestBase {
           "sentencingCourt":"$sentencingCourt",
           "sentencedUnder":"$sentencedUnder"
         }
-      """.trimIndent()
+    """.trimIndent()
 
     fun releaseRequestBody(
       dateOfRelease: String = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderCreateTest.kt
@@ -45,20 +45,18 @@ class OffenderCreateTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("custodyType", createOffenderRequestBody(custodyType = "")),
-        MandatoryFieldTestData("dateOfBirth", createOffenderRequestBody(dateOfBirth = "")),
-        MandatoryFieldTestData("dateOfSentence", createOffenderRequestBody(dateOfSentence = "")),
-        MandatoryFieldTestData("ethnicity", createOffenderRequestBody(ethnicity = "")),
-        MandatoryFieldTestData("firstNames", createOffenderRequestBody(firstNames = "")),
-        MandatoryFieldTestData("familyName", createOffenderRequestBody(familyName = "")),
-        MandatoryFieldTestData("gender", createOffenderRequestBody(gender = "")),
-        MandatoryFieldTestData("indexOffence", createOffenderRequestBody(indexOffence = "")),
-        MandatoryFieldTestData("mappaLevel", createOffenderRequestBody(mappaLevel = "")),
-        MandatoryFieldTestData("prisonNumber", createOffenderRequestBody(prisonNumber = "")),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("custodyType", createOffenderRequestBody(custodyType = "")),
+      MandatoryFieldTestData("dateOfBirth", createOffenderRequestBody(dateOfBirth = "")),
+      MandatoryFieldTestData("dateOfSentence", createOffenderRequestBody(dateOfSentence = "")),
+      MandatoryFieldTestData("ethnicity", createOffenderRequestBody(ethnicity = "")),
+      MandatoryFieldTestData("firstNames", createOffenderRequestBody(firstNames = "")),
+      MandatoryFieldTestData("familyName", createOffenderRequestBody(familyName = "")),
+      MandatoryFieldTestData("gender", createOffenderRequestBody(gender = "")),
+      MandatoryFieldTestData("indexOffence", createOffenderRequestBody(indexOffence = "")),
+      MandatoryFieldTestData("mappaLevel", createOffenderRequestBody(mappaLevel = "")),
+      MandatoryFieldTestData("prisonNumber", createOffenderRequestBody(prisonNumber = "")),
+    )
   }
 
   @AfterAll
@@ -329,11 +327,10 @@ class OffenderCreateTest : IntegrationTestBase() {
     return CreatedOffender(offenderId, CreatedSentence(sentenceId))
   }
 
-  private fun postOffender(requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.post()
-      .uri("/offender")
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun postOffender(requestBody: String): WebTestClient.ResponseSpec = webTestClient.post()
+    .uri("/offender")
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderOffenceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderOffenceUpdateTest.kt
@@ -29,23 +29,19 @@ class OffenderOffenceUpdateTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("indexOffence", updateOffenceRequestBody(indexOffence = "")),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("indexOffence", updateOffenceRequestBody(indexOffence = "")),
+    )
 
     private fun updateOffenceRequestBody(
       indexOffence: String = PPUD_VALID_INDEX_OFFENCE,
       dateOfIndexOffence: String = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE),
-    ): String {
-      return """ 
+    ): String = """ 
         {
           "indexOffence":"$indexOffence",
           "dateOfIndexOffence":"$dateOfIndexOffence" 
         }
-      """.trimIndent()
-    }
+    """.trimIndent()
   }
 
   @BeforeAll
@@ -136,14 +132,12 @@ class OffenderOffenceUpdateTest : IntegrationTestBase() {
       .isEmpty
   }
 
-  private fun putOffence(offenderId: String, sentenceId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.put()
-      .uri(constructUpdateOffenceUri(offenderId, sentenceId))
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun putOffence(offenderId: String, sentenceId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.put()
+    .uri(constructUpdateOffenceUri(offenderId, sentenceId))
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
-  private fun constructUpdateOffenceUri(offenderId: String, sentenceId: String) =
-    "/offender/$offenderId/sentence/$sentenceId/offence"
+  private fun constructUpdateOffenceUri(offenderId: String, sentenceId: String) = "/offender/$offenderId/sentence/$sentenceId/offence"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderRecallTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderRecallTest.kt
@@ -50,36 +50,34 @@ class OffenderRecallTest : IntegrationTestBase() {
     private const val PPUD_EXPECTED_RETURN_TO_CUSTODY_NOTIFICATION_METHOD = "Not Applicable"
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("decisionDateTime", createRecallRequestBody(decisionDateTime = "")),
-        MandatoryFieldTestData("mappaLevel", createRecallRequestBody(mappaLevel = "")),
-        MandatoryFieldTestData("policeForce", createRecallRequestBody(policeForce = "")),
-        MandatoryFieldTestData("probationArea", createRecallRequestBody(probationArea = "")),
-        MandatoryFieldTestData("receivedDateTime", createRecallRequestBody(receivedDateTime = "")),
-        MandatoryFieldTestData("recommendedTo", createRecallRequestBody(recommendedTo = null)),
-        MandatoryFieldTestData(
-          "recommendedTo",
-          createRecallRequestBody(recommendedTo = "{}"),
-          errorFragment = "fullName",
-        ),
-        MandatoryFieldTestData(
-          "recommendedTo",
-          createRecallRequestBody(recommendedTo = ppudUserRequestBody(fullName = "")),
-          errorFragment = "fullName",
-        ),
-        MandatoryFieldTestData(
-          "recommendedTo",
-          createRecallRequestBody(recommendedTo = ppudUserRequestBody(teamName = "")),
-          errorFragment = "team",
-        ),
-        MandatoryFieldTestData(
-          "riskOfSeriousHarmLevel",
-          createRecallRequestBody(riskOfSeriousHarmLevel = ""),
-          errorFragment = "RiskOfSeriousHarmLevel",
-        ),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("decisionDateTime", createRecallRequestBody(decisionDateTime = "")),
+      MandatoryFieldTestData("mappaLevel", createRecallRequestBody(mappaLevel = "")),
+      MandatoryFieldTestData("policeForce", createRecallRequestBody(policeForce = "")),
+      MandatoryFieldTestData("probationArea", createRecallRequestBody(probationArea = "")),
+      MandatoryFieldTestData("receivedDateTime", createRecallRequestBody(receivedDateTime = "")),
+      MandatoryFieldTestData("recommendedTo", createRecallRequestBody(recommendedTo = null)),
+      MandatoryFieldTestData(
+        "recommendedTo",
+        createRecallRequestBody(recommendedTo = "{}"),
+        errorFragment = "fullName",
+      ),
+      MandatoryFieldTestData(
+        "recommendedTo",
+        createRecallRequestBody(recommendedTo = ppudUserRequestBody(fullName = "")),
+        errorFragment = "fullName",
+      ),
+      MandatoryFieldTestData(
+        "recommendedTo",
+        createRecallRequestBody(recommendedTo = ppudUserRequestBody(teamName = "")),
+        errorFragment = "team",
+      ),
+      MandatoryFieldTestData(
+        "riskOfSeriousHarmLevel",
+        createRecallRequestBody(riskOfSeriousHarmLevel = ""),
+        errorFragment = "RiskOfSeriousHarmLevel",
+      ),
+    )
   }
 
   @BeforeAll
@@ -237,6 +235,5 @@ class OffenderRecallTest : IntegrationTestBase() {
     return id
   }
 
-  private fun constructUri(offenderId: String, releaseId: String) =
-    "/offender/$offenderId/release/$releaseId/recall"
+  private fun constructUri(offenderId: String, releaseId: String) = "/offender/$offenderId/release/$releaseId/recall"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderReleaseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderReleaseTest.kt
@@ -25,13 +25,11 @@ class OffenderReleaseTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("dateOfRelease", releaseRequestBody(dateOfRelease = "")),
-        MandatoryFieldTestData("releasedFrom", releaseRequestBody(releasedFrom = "")),
-        MandatoryFieldTestData("releasedUnder", releaseRequestBody(releasedUnder = "")),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("dateOfRelease", releaseRequestBody(dateOfRelease = "")),
+      MandatoryFieldTestData("releasedFrom", releaseRequestBody(releasedFrom = "")),
+      MandatoryFieldTestData("releasedUnder", releaseRequestBody(releasedUnder = "")),
+    )
   }
 
   @AfterAll
@@ -141,14 +139,12 @@ class OffenderReleaseTest : IntegrationTestBase() {
       .jsonPath("offender.sentences[0].id").isEqualTo(sentenceId)
   }
 
-  private fun postRelease(offenderId: String, sentenceId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.post()
-      .uri(constructUri(offenderId, sentenceId))
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun postRelease(offenderId: String, sentenceId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.post()
+    .uri(constructUri(offenderId, sentenceId))
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
-  private fun constructUri(offenderId: String, sentenceId: String) =
-    "/offender/$offenderId/sentence/$sentenceId/release"
+  private fun constructUri(offenderId: String, sentenceId: String) = "/offender/$offenderId/sentence/$sentenceId/release"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
@@ -29,13 +29,11 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("custodyType", createOrUpdateSentenceRequestBody(custodyType = "")),
-        MandatoryFieldTestData("dateOfSentence", createOrUpdateSentenceRequestBody(dateOfSentence = "")),
-        MandatoryFieldTestData("mappaLevel", createOrUpdateSentenceRequestBody(mappaLevel = "")),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("custodyType", createOrUpdateSentenceRequestBody(custodyType = "")),
+      MandatoryFieldTestData("dateOfSentence", createOrUpdateSentenceRequestBody(dateOfSentence = "")),
+      MandatoryFieldTestData("mappaLevel", createOrUpdateSentenceRequestBody(mappaLevel = "")),
+    )
   }
 
   @AfterAll
@@ -244,14 +242,12 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
     return id
   }
 
-  private fun postSentence(offenderId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.post()
-      .uri(constructCreateSentenceUri(offenderId))
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun postSentence(offenderId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.post()
+    .uri(constructCreateSentenceUri(offenderId))
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
-  private fun constructCreateSentenceUri(offenderId: String) =
-    "/offender/$offenderId/sentence"
+  private fun constructCreateSentenceUri(offenderId: String) = "/offender/$offenderId/sentence"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceUpdateTest.kt
@@ -32,11 +32,9 @@ class OffenderSentenceUpdateTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("custodyType", createOrUpdateSentenceRequestBody(custodyType = "")),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("custodyType", createOrUpdateSentenceRequestBody(custodyType = "")),
+    )
   }
 
   @BeforeAll
@@ -177,14 +175,12 @@ class OffenderSentenceUpdateTest : IntegrationTestBase() {
       .isEmpty
   }
 
-  private fun putSentence(offenderId: String, sentenceId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.put()
-      .uri(constructUpdateSentenceUri(offenderId, sentenceId))
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun putSentence(offenderId: String, sentenceId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.put()
+    .uri(constructUpdateSentenceUri(offenderId, sentenceId))
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
-  private fun constructUpdateSentenceUri(offenderId: String, sentenceId: String) =
-    "/offender/$offenderId/sentence/$sentenceId"
+  private fun constructUpdateSentenceUri(offenderId: String, sentenceId: String) = "/offender/$offenderId/sentence/$sentenceId"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderUpdateTest.kt
@@ -44,16 +44,14 @@ class OffenderUpdateTest : IntegrationTestBase() {
     val familyNameToDeleteUuids = mutableSetOf<UUID>()
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("dateOfBirth", updateOffenderRequestBody(dateOfBirth = "")),
-        MandatoryFieldTestData("ethnicity", updateOffenderRequestBody(ethnicity = "")),
-        MandatoryFieldTestData("familyName", updateOffenderRequestBody(familyName = "")),
-        MandatoryFieldTestData("firstNames", updateOffenderRequestBody(firstNames = "")),
-        MandatoryFieldTestData("gender", updateOffenderRequestBody(gender = "")),
-        MandatoryFieldTestData("prisonNumber", updateOffenderRequestBody(prisonNumber = "")),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("dateOfBirth", updateOffenderRequestBody(dateOfBirth = "")),
+      MandatoryFieldTestData("ethnicity", updateOffenderRequestBody(ethnicity = "")),
+      MandatoryFieldTestData("familyName", updateOffenderRequestBody(familyName = "")),
+      MandatoryFieldTestData("firstNames", updateOffenderRequestBody(firstNames = "")),
+      MandatoryFieldTestData("gender", updateOffenderRequestBody(gender = "")),
+      MandatoryFieldTestData("prisonNumber", updateOffenderRequestBody(prisonNumber = "")),
+    )
   }
 
   @BeforeAll

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/recall/RecallAdditionalDocumentUploadTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/recall/RecallAdditionalDocumentUploadTest.kt
@@ -31,42 +31,38 @@ class RecallAdditionalDocumentUploadTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("documentId", uploadAdditionalDocumentRequestBody(documentId = "")),
-        MandatoryFieldTestData("title", uploadAdditionalDocumentRequestBody(title = ""), "title"),
-        MandatoryFieldTestData("owningCaseworker", uploadAdditionalDocumentRequestBody(owningCaseworker = null)),
-        MandatoryFieldTestData(
-          "owningCaseworker",
-          uploadAdditionalDocumentRequestBody(owningCaseworker = "{}"),
-          errorFragment = "fullName",
-        ),
-        MandatoryFieldTestData(
-          "owningCaseworker",
-          uploadAdditionalDocumentRequestBody(owningCaseworker = ppudUserRequestBody(fullName = "")),
-          errorFragment = "fullName",
-        ),
-        MandatoryFieldTestData(
-          "owningCaseworker",
-          uploadAdditionalDocumentRequestBody(owningCaseworker = ppudUserRequestBody(teamName = "")),
-          errorFragment = "team",
-        ),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("documentId", uploadAdditionalDocumentRequestBody(documentId = "")),
+      MandatoryFieldTestData("title", uploadAdditionalDocumentRequestBody(title = ""), "title"),
+      MandatoryFieldTestData("owningCaseworker", uploadAdditionalDocumentRequestBody(owningCaseworker = null)),
+      MandatoryFieldTestData(
+        "owningCaseworker",
+        uploadAdditionalDocumentRequestBody(owningCaseworker = "{}"),
+        errorFragment = "fullName",
+      ),
+      MandatoryFieldTestData(
+        "owningCaseworker",
+        uploadAdditionalDocumentRequestBody(owningCaseworker = ppudUserRequestBody(fullName = "")),
+        errorFragment = "fullName",
+      ),
+      MandatoryFieldTestData(
+        "owningCaseworker",
+        uploadAdditionalDocumentRequestBody(owningCaseworker = ppudUserRequestBody(teamName = "")),
+        errorFragment = "team",
+      ),
+    )
 
     fun uploadAdditionalDocumentRequestBody(
       documentId: String = UUID.randomUUID().toString(),
       title: String? = randomString("title"),
       owningCaseworker: String? = ppudUserRequestBody(),
-    ): String {
-      return """
+    ): String = """
         { 
           "documentId":"$documentId", 
           "title":"$title",
           "owningCaseworker":${owningCaseworker ?: "null"}
         }
-      """.trimIndent()
-    }
+    """.trimIndent()
   }
 
   @BeforeAll
@@ -154,13 +150,12 @@ class RecallAdditionalDocumentUploadTest : IntegrationTestBase() {
       .jsonPath("recall.documents[0].owningCaseworker").isEqualTo(PPUD_VALID_USER_FULL_NAME)
   }
 
-  private fun putAdditionalDocument(recallId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.put()
-      .uri(constructUri(recallId))
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun putAdditionalDocument(recallId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.put()
+    .uri(constructUri(recallId))
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
   private fun constructUri(recallId: String) = "/recall/$recallId/additional-document"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/recall/RecallMandatoryDocumentUploadTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/recall/RecallMandatoryDocumentUploadTest.kt
@@ -33,42 +33,38 @@ class RecallMandatoryDocumentUploadTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("documentId", uploadMandatoryDocumentRequestBody(documentId = "")),
-        MandatoryFieldTestData("category", uploadMandatoryDocumentRequestBody(category = ""), "DocumentCategory"),
-        MandatoryFieldTestData("owningCaseworker", uploadMandatoryDocumentRequestBody(owningCaseworker = null)),
-        MandatoryFieldTestData(
-          "owningCaseworker",
-          uploadMandatoryDocumentRequestBody(owningCaseworker = "{}"),
-          errorFragment = "fullName",
-        ),
-        MandatoryFieldTestData(
-          "owningCaseworker",
-          uploadMandatoryDocumentRequestBody(owningCaseworker = ppudUserRequestBody(fullName = "")),
-          errorFragment = "fullName",
-        ),
-        MandatoryFieldTestData(
-          "owningCaseworker",
-          uploadMandatoryDocumentRequestBody(owningCaseworker = ppudUserRequestBody(teamName = "")),
-          errorFragment = "team",
-        ),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("documentId", uploadMandatoryDocumentRequestBody(documentId = "")),
+      MandatoryFieldTestData("category", uploadMandatoryDocumentRequestBody(category = ""), "DocumentCategory"),
+      MandatoryFieldTestData("owningCaseworker", uploadMandatoryDocumentRequestBody(owningCaseworker = null)),
+      MandatoryFieldTestData(
+        "owningCaseworker",
+        uploadMandatoryDocumentRequestBody(owningCaseworker = "{}"),
+        errorFragment = "fullName",
+      ),
+      MandatoryFieldTestData(
+        "owningCaseworker",
+        uploadMandatoryDocumentRequestBody(owningCaseworker = ppudUserRequestBody(fullName = "")),
+        errorFragment = "fullName",
+      ),
+      MandatoryFieldTestData(
+        "owningCaseworker",
+        uploadMandatoryDocumentRequestBody(owningCaseworker = ppudUserRequestBody(teamName = "")),
+        errorFragment = "team",
+      ),
+    )
 
     fun uploadMandatoryDocumentRequestBody(
       documentId: String = UUID.randomUUID().toString(),
       category: String? = randomDocumentCategory().toString(),
       owningCaseworker: String? = ppudUserRequestBody(),
-    ): String {
-      return """
+    ): String = """
         { 
           "documentId":"$documentId", 
           "category":"$category",
           "owningCaseworker":${owningCaseworker ?: "null"}
         }
-      """.trimIndent()
-    }
+    """.trimIndent()
   }
 
   @BeforeAll
@@ -207,13 +203,12 @@ class RecallMandatoryDocumentUploadTest : IntegrationTestBase() {
       .jsonPath("recall.allMandatoryDocumentsReceived").isEqualTo("Yes")
   }
 
-  private fun putDocument(recallId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.put()
-      .uri(constructUri(recallId))
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun putDocument(recallId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.put()
+    .uri(constructUri(recallId))
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
   private fun constructUri(recallId: String) = "/recall/$recallId/mandatory-document"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/recall/RecallMinuteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/recall/RecallMinuteTest.kt
@@ -27,24 +27,20 @@ class RecallMinuteTest : IntegrationTestBase() {
   companion object {
 
     @JvmStatic
-    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> {
-      return Stream.of(
-        MandatoryFieldTestData("subject", addMinuteRequestBody(subject = "")),
-        MandatoryFieldTestData("text", addMinuteRequestBody(text = "")),
-      )
-    }
+    private fun mandatoryFieldTestData(): Stream<MandatoryFieldTestData> = Stream.of(
+      MandatoryFieldTestData("subject", addMinuteRequestBody(subject = "")),
+      MandatoryFieldTestData("text", addMinuteRequestBody(text = "")),
+    )
 
     fun addMinuteRequestBody(
       subject: String = randomString("subject"),
       text: String = randomString("text"),
-    ): String {
-      return """
+    ): String = """
         { 
           "subject":"$subject", 
           "text":"$text"
         }
-      """.trimIndent()
-    }
+    """.trimIndent()
   }
 
   @BeforeAll
@@ -153,13 +149,12 @@ class RecallMinuteTest : IntegrationTestBase() {
       .jsonPath("recall.minutes[1].text").isEqualTo("123${System.lineSeparator()}456")
   }
 
-  private fun putMinute(recallId: String, requestBody: String): WebTestClient.ResponseSpec =
-    webTestClient.put()
-      .uri(constructUri(recallId))
-      .headers { it.authToken() }
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(requestBody))
-      .exchange()
+  private fun putMinute(recallId: String, requestBody: String): WebTestClient.ResponseSpec = webTestClient.put()
+    .uri(constructUri(recallId))
+    .headers { it.authToken() }
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(requestBody))
+    .exchange()
 
   private fun constructUri(recallId: String) = "/recall/$recallId/minutes"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/ReferenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/ReferenceServiceTest.kt
@@ -57,8 +57,7 @@ class ReferenceServiceTest {
     fun cacheManager(): CacheManager = ConcurrentMapCacheManager(*Companion.cacheNames)
 
     @Bean
-    fun referenceService(ppudClient: ReferenceDataPpudClient, cacheManager: CacheManager): ReferenceService =
-      ReferenceServiceImpl(ppudClient, cacheManager)
+    fun referenceService(ppudClient: ReferenceDataPpudClient, cacheManager: CacheManager): ReferenceService = ReferenceServiceImpl(ppudClient, cacheManager)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
@@ -96,9 +96,7 @@ private const val SIXTY_YEARS_IN_DAYS: Long = 21900
 
 private const val SECONDS_IN_A_DAY: Long = 86400
 
-fun randomString(prefix: String = "random"): String {
-  return "$prefix-${UUID.randomUUID()}"
-}
+fun randomString(prefix: String = "random"): String = "$prefix-${UUID.randomUUID()}"
 
 fun randomCroNumber(): String {
   val serial = Random.nextInt(100000, 999999)
@@ -119,9 +117,7 @@ fun randomPrisonNumber(): String {
   return number
 }
 
-fun randomDate(): LocalDate {
-  return LocalDate.parse("2005-01-01").minusDays(Random.nextLong(SIXTY_YEARS_IN_DAYS))
-}
+fun randomDate(): LocalDate = LocalDate.parse("2005-01-01").minusDays(Random.nextLong(SIXTY_YEARS_IN_DAYS))
 
 fun randomDateTime(): LocalDateTime {
   val earliest = LocalDateTime.parse("2000-01-01T00:00:00")
@@ -130,9 +126,7 @@ fun randomDateTime(): LocalDateTime {
   return LocalDateTime.ofEpochSecond(randomEpochSecond, 0, ZoneOffset.UTC)
 }
 
-fun randomTimeToday(): LocalDateTime {
-  return LocalDate.now().atTime(LocalTime.ofSecondOfDay(Random.nextLong(SECONDS_IN_A_DAY)))
-}
+fun randomTimeToday(): LocalDateTime = LocalDate.now().atTime(LocalTime.ofSecondOfDay(Random.nextLong(SECONDS_IN_A_DAY)))
 
 fun randomPhoneNumber(): String {
   val number = Random.nextInt(100000000, 999999999)
@@ -159,57 +153,47 @@ fun randomPpudId(): String {
   return "4F${randomSerial}E64657269643D313632393134G721H665"
 }
 
-fun randomLookupName(exclude: List<LookupName> = listOf()): LookupName {
-  return LookupName.entries.filter { exclude.contains(it).not() }.shuffled().first()
-}
+fun randomLookupName(exclude: List<LookupName> = listOf()): LookupName = LookupName.entries.filter { exclude.contains(it).not() }.shuffled().first()
 
-fun randomRiskOfSeriousHarmLevel(): RiskOfSeriousHarmLevel {
-  return RiskOfSeriousHarmLevel.entries.shuffled().first()
-}
+fun randomRiskOfSeriousHarmLevel(): RiskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.entries.shuffled().first()
 
-fun randomDocumentCategory(exclude: DocumentCategory? = null): DocumentCategory {
-  return DocumentCategory.entries.shuffled().first { it != exclude }
-}
+fun randomDocumentCategory(exclude: DocumentCategory? = null): DocumentCategory = DocumentCategory.entries.shuffled().first { it != exclude }
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
  * so some of the values won't be acceptable to PPUD.
  */
-fun generateCreateOffenderRequest(): CreateOffenderRequest {
-  return CreateOffenderRequest(
-    address = generateOffenderAddress(),
-    croNumber = randomCroNumber(),
-    custodyType = randomString("custodyType"),
-    dateOfBirth = randomDate(),
-    dateOfSentence = randomDate(),
-    ethnicity = randomString("ethnicity"),
-    firstNames = randomString("firstNames"),
-    familyName = randomString("familyName"),
-    gender = randomString("gender"),
-    indexOffence = randomString("indexOffence"),
-    isInCustody = Random.nextBoolean(),
-    mappaLevel = randomString("mappaLevel"),
-    nomsId = randomNomsId(),
-    prisonNumber = randomPrisonNumber(),
-  )
-}
+fun generateCreateOffenderRequest(): CreateOffenderRequest = CreateOffenderRequest(
+  address = generateOffenderAddress(),
+  croNumber = randomCroNumber(),
+  custodyType = randomString("custodyType"),
+  dateOfBirth = randomDate(),
+  dateOfSentence = randomDate(),
+  ethnicity = randomString("ethnicity"),
+  firstNames = randomString("firstNames"),
+  familyName = randomString("familyName"),
+  gender = randomString("gender"),
+  indexOffence = randomString("indexOffence"),
+  isInCustody = Random.nextBoolean(),
+  mappaLevel = randomString("mappaLevel"),
+  nomsId = randomNomsId(),
+  prisonNumber = randomPrisonNumber(),
+)
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
  * so some of the values won't be acceptable to PPUD.
  */
-fun generateUpdateOffenderRequest(): UpdateOffenderRequest {
-  return UpdateOffenderRequest(
-    croNumber = randomCroNumber(),
-    dateOfBirth = randomDate(),
-    ethnicity = randomString("ethnicity"),
-    familyName = randomString("familyName"),
-    firstNames = randomString("firstNames"),
-    gender = randomString("gender"),
-    isInCustody = Random.nextBoolean(),
-    prisonNumber = randomPrisonNumber(),
-  )
-}
+fun generateUpdateOffenderRequest(): UpdateOffenderRequest = UpdateOffenderRequest(
+  croNumber = randomCroNumber(),
+  dateOfBirth = randomDate(),
+  ethnicity = randomString("ethnicity"),
+  familyName = randomString("familyName"),
+  firstNames = randomString("firstNames"),
+  gender = randomString("gender"),
+  isInCustody = Random.nextBoolean(),
+  prisonNumber = randomPrisonNumber(),
+)
 
 fun generateOffender(id: String = randomPpudId()): Offender {
   val croOtherNumber = randomCroNumber()
@@ -253,15 +237,13 @@ fun generateSearchResultOffender(
   )
 }
 
-fun generateOffenderAddress(): OffenderAddress {
-  return OffenderAddress(
-    premises = randomString("premises"),
-    line1 = randomString("line1"),
-    line2 = randomString("line2"),
-    postcode = randomString("postcode"),
-    phoneNumber = randomString("phoneNumber"),
-  )
-}
+fun generateOffenderAddress(): OffenderAddress = OffenderAddress(
+  premises = randomString("premises"),
+  line1 = randomString("line1"),
+  line2 = randomString("line2"),
+  postcode = randomString("postcode"),
+  phoneNumber = randomString("phoneNumber"),
+)
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
@@ -272,31 +254,27 @@ fun generateCreateOrUpdateSentenceRequest(
   dateOfSentence: LocalDate = randomDate(),
   mappaLevel: String = randomString("mappaLevel"),
   sentencingCourt: String = randomString("sentencingCourt"),
-): CreateOrUpdateSentenceRequest {
-  return CreateOrUpdateSentenceRequest(
-    custodyType = custodyType,
-    dateOfSentence = dateOfSentence,
-    espCustodialPeriod = null,
-    espExtendedPeriod = null,
-    licenceExpiryDate = null,
-    mappaLevel = mappaLevel,
-    releaseDate = randomDate(),
-    sentenceExpiryDate = null,
-    sentenceLength = null,
-    sentencingCourt = sentencingCourt,
-  )
-}
+): CreateOrUpdateSentenceRequest = CreateOrUpdateSentenceRequest(
+  custodyType = custodyType,
+  dateOfSentence = dateOfSentence,
+  espCustodialPeriod = null,
+  espExtendedPeriod = null,
+  licenceExpiryDate = null,
+  mappaLevel = mappaLevel,
+  releaseDate = randomDate(),
+  sentenceExpiryDate = null,
+  sentenceLength = null,
+  sentencingCourt = sentencingCourt,
+)
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
  * so some of the values won't be acceptable to PPUD.
  */
-fun generateUpdateOffenceRequest(): UpdateOffenceRequest {
-  return UpdateOffenceRequest(
-    indexOffence = randomString("indexOffence"),
-    dateOfIndexOffence = randomDate(),
-  )
-}
+fun generateUpdateOffenceRequest(): UpdateOffenceRequest = UpdateOffenceRequest(
+  indexOffence = randomString("indexOffence"),
+  dateOfIndexOffence = randomDate(),
+)
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
@@ -306,13 +284,11 @@ fun generateCreateOrUpdateReleaseRequest(
   dateOfRelease: LocalDate = randomDate(),
   releasedFrom: String = randomString("releasedFrom"),
   releasedUnder: String = randomString("releasedUnder"),
-): CreateOrUpdateReleaseRequest {
-  return CreateOrUpdateReleaseRequest(
-    dateOfRelease = dateOfRelease,
-    releasedFrom = releasedFrom,
-    releasedUnder = releasedUnder,
-  )
-}
+): CreateOrUpdateReleaseRequest = CreateOrUpdateReleaseRequest(
+  dateOfRelease = dateOfRelease,
+  releasedFrom = releasedFrom,
+  releasedUnder = releasedUnder,
+)
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
@@ -325,20 +301,18 @@ fun generateCreateRecallRequest(
   recommendedTo: PpudUser = generatePpudUser(),
   riskOfContrabandDetails: String? = null,
   riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel? = null,
-): CreateRecallRequest {
-  return CreateRecallRequest(
-    decisionDateTime = randomTimeToday(),
-    isExtendedSentence = isExtendedSentence ?: Random.nextBoolean(),
-    isInCustody = isInCustody ?: Random.nextBoolean(),
-    mappaLevel = randomString("mappaLevel"),
-    policeForce = randomString("policeForce"),
-    probationArea = randomString("probationArea"),
-    receivedDateTime = receivedDateTime,
-    recommendedTo = recommendedTo,
-    riskOfContrabandDetails = riskOfContrabandDetails ?: randomString("riskOfContrabandDetails"),
-    riskOfSeriousHarmLevel = riskOfSeriousHarmLevel ?: randomRiskOfSeriousHarmLevel(),
-  )
-}
+): CreateRecallRequest = CreateRecallRequest(
+  decisionDateTime = randomTimeToday(),
+  isExtendedSentence = isExtendedSentence ?: Random.nextBoolean(),
+  isInCustody = isInCustody ?: Random.nextBoolean(),
+  mappaLevel = randomString("mappaLevel"),
+  policeForce = randomString("policeForce"),
+  probationArea = randomString("probationArea"),
+  receivedDateTime = receivedDateTime,
+  recommendedTo = recommendedTo,
+  riskOfContrabandDetails = riskOfContrabandDetails ?: randomString("riskOfContrabandDetails"),
+  riskOfSeriousHarmLevel = riskOfSeriousHarmLevel ?: randomRiskOfSeriousHarmLevel(),
+)
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
@@ -347,13 +321,11 @@ fun generateCreateRecallRequest(
 fun generateUploadMandatoryDocumentRequest(
   documentId: UUID = UUID.randomUUID(),
   owningCaseworker: PpudUser = generatePpudUser(),
-): UploadMandatoryDocumentRequest {
-  return UploadMandatoryDocumentRequest(
-    documentId = documentId,
-    category = randomDocumentCategory(),
-    owningCaseworker = owningCaseworker,
-  )
-}
+): UploadMandatoryDocumentRequest = UploadMandatoryDocumentRequest(
+  documentId = documentId,
+  category = randomDocumentCategory(),
+  owningCaseworker = owningCaseworker,
+)
 
 /**
  * This will create a request that is useful for mocked testing but uses random values
@@ -362,53 +334,43 @@ fun generateUploadMandatoryDocumentRequest(
 fun generateUploadAdditionalDocumentRequest(
   documentId: UUID = UUID.randomUUID(),
   owningCaseworker: PpudUser = generatePpudUser(),
-): UploadAdditionalDocumentRequest {
-  return UploadAdditionalDocumentRequest(
-    documentId = documentId,
-    title = randomString("title"),
-    owningCaseworker = owningCaseworker,
-  )
-}
+): UploadAdditionalDocumentRequest = UploadAdditionalDocumentRequest(
+  documentId = documentId,
+  title = randomString("title"),
+  owningCaseworker = owningCaseworker,
+)
 
 fun generateAddMinuteRequest(
   subject: String = randomString("subject"),
   text: String = randomString("text"),
-): AddMinuteRequest {
-  return AddMinuteRequest(
-    subject = subject,
-    text = text,
-  )
-}
+): AddMinuteRequest = AddMinuteRequest(
+  subject = subject,
+  text = text,
+)
 
-fun generateRecall(id: String = randomPpudId()): Recall {
-  return Recall(
-    id = id,
-    allMandatoryDocumentsReceived = "No",
-    decisionDateTime = randomTimeToday(),
-    documents = emptyList(),
-    isInCustody = Random.nextBoolean(),
-    minutes = emptyList(),
-    missingMandatoryDocuments = emptyList(),
-    owningTeam = randomString("owningTeam"),
-    policeForce = randomString("policeForce"),
-    probationArea = randomString("probationArea"),
-    recallType = randomString("recallType"),
-    receivedDateTime = randomTimeToday(),
-    mappaLevel = randomString("mappaLevel"),
-    recommendedToOwner = randomString("recommendedToOwner"),
-    recommendedToDateTime = randomTimeToday(),
-    revocationIssuedByOwner = randomString("revocationIssuedByOwner"),
-    returnToCustodyNotificationMethod = randomString("returnToCustodyNotificationMethod"),
-  )
-}
+fun generateRecall(id: String = randomPpudId()): Recall = Recall(
+  id = id,
+  allMandatoryDocumentsReceived = "No",
+  decisionDateTime = randomTimeToday(),
+  documents = emptyList(),
+  isInCustody = Random.nextBoolean(),
+  minutes = emptyList(),
+  missingMandatoryDocuments = emptyList(),
+  owningTeam = randomString("owningTeam"),
+  policeForce = randomString("policeForce"),
+  probationArea = randomString("probationArea"),
+  recallType = randomString("recallType"),
+  receivedDateTime = randomTimeToday(),
+  mappaLevel = randomString("mappaLevel"),
+  recommendedToOwner = randomString("recommendedToOwner"),
+  recommendedToDateTime = randomTimeToday(),
+  revocationIssuedByOwner = randomString("revocationIssuedByOwner"),
+  returnToCustodyNotificationMethod = randomString("returnToCustodyNotificationMethod"),
+)
 
-fun generatePpudUser(): PpudUser {
-  return PpudUser(
-    fullName = randomString("fullName"),
-    teamName = randomString("teamName"),
-  )
-}
+fun generatePpudUser(): PpudUser = PpudUser(
+  fullName = randomString("fullName"),
+  teamName = randomString("teamName"),
+)
 
-fun generateUserSearchRequest(fullName: String?, userName: String?): UserSearchRequest {
-  return UserSearchRequest(fullName, userName)
-}
+fun generateUserSearchRequest(fullName: String?, userName: String?): UserSearchRequest = UserSearchRequest(fullName, userName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
@@ -256,6 +256,7 @@ fun generateCreateOrUpdateSentenceRequest(
   dateOfSentence: LocalDate = randomDate(),
   mappaLevel: String = randomString("mappaLevel"),
   sentencingCourt: String = randomString("sentencingCourt"),
+  sentencedUnder: String = randomString("sentencedUnder"),
 ): CreateOrUpdateSentenceRequest = CreateOrUpdateSentenceRequest(
   custodyType = custodyType,
   dateOfSentence = dateOfSentence,


### PR DESCRIPTION
- 3 commits to allow bump of non-major dependency versions

- Forcing ktlint ver bump to resolve KtModifierKeywordToken HEADER_KEYWORD not longer present (see https://github.com/JLLeitschuh/ktlint-gradle/issues/809)
- Formatting changes enforced by ktlint (removal of function body) (see https://pinterest.github.io/ktlint/latest/rules/standard/#function-signature)
- Changes to ensure nullable strings returned from java classes are handled correctly for non-nullable Kotlin Strings (now detected by kotlin ver bump). Example, Java function  `driver.title` which returns a Java String becomes `driver.title.orEmpty()` when returned as a Kotlin String
- Change to TreeViewNode return types from nullable to non-nullable types on base WebElement Selenium interfaces (changes due to Selenium bump)