### PR TITLE
Suppression of CVE-2024-50379 detected by trivy scan

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,6 @@
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for tomcat vulnerability affecting jsp compilation in the default servlet
+#   can be suppressed as we do not use the default servlet and haven't configured it for write either
+CVE-2024-50379


### PR DESCRIPTION
Suppression for tomcat vulnerability affecting jsp compilation in the default servlet can be suppressed as we do not use the default servlet and haven't configured it for write either