### PR TITLE
OWASP scan vuln CVE-2024-12798 and CVE-2024-12801

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 }
 
 jacoco.toolVersion = "0.8.11"
+// OWASP fix https://mojdt.slack.com/archives/C69NWE339/p1734943189790819
+ext["logback.version"] = "1.5.14"
 
 configurations {
   testImplementation { exclude(group = "org.junit.vintage") }


### PR DESCRIPTION
both fixed in logback ver 1.5.13, but that is not included in the latest spring boot 3.4.1 release, which still targets 1.5.12, therefore forcing 1.5.14
see https://mojdt.slack.com/archives/C69NWE339/p1734943189790819