### PR TITLE
MRD-2609 Support 'Sentenced Under' field setting

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparator.kt
@@ -15,6 +15,7 @@ class SentenceComparator {
       existing.sentenceLength?.partMonths == request.sentenceLength?.partMonths &&
       existing.sentenceLength?.partDays == request.sentenceLength?.partDays &&
       existing.licenceExpiryDate == request.licenceExpiryDate &&
-      existing.sentenceExpiryDate == request.sentenceExpiryDate
+      existing.sentenceExpiryDate == request.sentenceExpiryDate &&
+      existing.sentencedUnder == request.sentencedUnder
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateOrUpdateSentenceRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateOrUpdateSentenceRequest.kt
@@ -22,5 +22,6 @@ data class CreateOrUpdateSentenceRequest(
   val sentenceExpiryDate: LocalDate?,
   @field:Size(min = 0, max = 50)
   val sentencingCourt: String = "",
-  val sentencedUnder: String = "",
+  @field:NotBlank
+  val sentencedUnder: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateOrUpdateSentenceRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateOrUpdateSentenceRequest.kt
@@ -22,4 +22,5 @@ data class CreateOrUpdateSentenceRequest(
   val sentenceExpiryDate: LocalDate?,
   @field:Size(min = 0, max = 50)
   val sentencingCourt: String = "",
+  val sentencedUnder: String = "",
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentenceDeterminatePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentenceDeterminatePage.kt
@@ -25,7 +25,6 @@ internal class SentenceDeterminatePage(
   pageHelper: PageHelper,
   navigationTreeViewComponent: NavigationTreeViewComponent,
   sentenceComparator: SentenceComparator,
-  @Value("\${ppud.sentence.sentencedUnder}") private val sentencedUnder: String,
 ) : SentencePage(driver, pageHelper, navigationTreeViewComponent, sentenceComparator) {
 
   @FindBy(id = "cntDetails_PageFooter1_cmdSave")
@@ -104,7 +103,7 @@ internal class SentenceDeterminatePage(
       enterDate(licenceExpiryDateInput, request.licenceExpiryDate)
       selectDropdownOptionIfNotBlank(mappaLevelDropdown, request.mappaLevel, "mappa level")
       enterDate(releaseDateInput, request.releaseDate)
-      selectDropdownOptionIfNotBlank(sentencedUnderDropdown, sentencedUnder, "sentenced under")
+      selectDropdownOptionIfNotBlank(sentencedUnderDropdown, request.sentencedUnder, "sentenced under")
       enterDate(sentenceExpiryDateInput, request.sentenceExpiryDate)
       enterText(sentencingCourtInput, request.sentencingCourt)
       enterInteger(sentenceLengthPartYearsInput, request.sentenceLength?.partYears)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentenceDeterminatePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/SentenceDeterminatePage.kt
@@ -5,7 +5,6 @@ import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.support.FindBy
 import org.openqa.selenium.support.PageFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.SentenceComparator
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.CreatedSentence

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,8 +85,6 @@ ppud:
     status: "Recalled [*]"
     youngOffenderYes: "Yes - Named"
     youngOffenderNo: "No"
-  sentence:
-    sentencedUnder: "Not Specified"
   release:
     category: "Not Applicable"
     releaseType: "On Licence"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparatorTest.kt
@@ -36,6 +36,7 @@ internal class SentenceComparatorTest {
         "sentenceLength.partMonths",
         "sentenceLength.partDays",
         "sentencingCourt",
+        "sentencedUnder",
       )
     }
   }
@@ -46,7 +47,7 @@ internal class SentenceComparatorTest {
   }
 
   @Test
-  fun `given all key values are populated with matching vales when areMatching is called then true is returned`() {
+  fun `given all key values are populated with matching values when areMatching is called then true is returned`() {
     val existing = Sentence(
       id = "",
       custodyType = randomString("custodyType"),
@@ -56,6 +57,7 @@ internal class SentenceComparatorTest {
       sentenceExpiryDate = randomDate(),
       sentenceLength = SentenceLength(Random.nextInt(), Random.nextInt(), Random.nextInt()),
       sentencingCourt = randomString("sentencingCourt"),
+      sentencedUnder = randomString("sentencedUnder"),
     )
     val request = CreateOrUpdateSentenceRequest(
       custodyType = existing.custodyType,
@@ -72,6 +74,7 @@ internal class SentenceComparatorTest {
       espCustodialPeriod = null,
       espExtendedPeriod = null,
       releaseDate = null,
+      sentencedUnder = existing.sentencedUnder!!,
     )
     val result = comparator.areMatching(existing, request)
     assertTrue(result)
@@ -88,6 +91,7 @@ internal class SentenceComparatorTest {
       sentenceExpiryDate = null,
       sentenceLength = null,
       sentencingCourt = randomString("sentencingCourt"),
+      sentencedUnder = randomString("sentencedUnder"),
     )
     val request = CreateOrUpdateSentenceRequest(
       custodyType = existing.custodyType,
@@ -100,9 +104,43 @@ internal class SentenceComparatorTest {
       espCustodialPeriod = null,
       espExtendedPeriod = null,
       releaseDate = null,
+      sentencedUnder = existing.sentencedUnder!!,
     )
     val result = comparator.areMatching(existing, request)
     assertTrue(result)
+  }
+
+  @Test
+  fun `given all fields but sentencedUnder are populated with matching values when areMatching is called then false is returned`() {
+    // We have this test because Sentence allows a null sentencedUnder (indeterminate sentences have a null value here)
+    // but CreateOrUpdateSentenceRequest doesn't (only determinate sentences are ever created or updated, and they
+    // always have a value for sentencedUnder). We want to make sure null vs !null is covered.
+    val existing = Sentence(
+      id = "",
+      custodyType = randomString("custodyType"),
+      dateOfSentence = randomDate(),
+      mappaLevel = randomString("mappaLevel"),
+      licenceExpiryDate = null,
+      sentenceExpiryDate = null,
+      sentenceLength = null,
+      sentencingCourt = randomString("sentencingCourt"),
+      sentencedUnder = null,
+    )
+    val request = CreateOrUpdateSentenceRequest(
+      custodyType = existing.custodyType,
+      dateOfSentence = existing.dateOfSentence,
+      mappaLevel = existing.mappaLevel,
+      licenceExpiryDate = null,
+      sentenceExpiryDate = null,
+      sentenceLength = null,
+      sentencingCourt = existing.sentencingCourt,
+      espCustodialPeriod = null,
+      espExtendedPeriod = null,
+      releaseDate = null,
+      sentencedUnder = randomString("sentencedUnder"),
+    )
+    val result = comparator.areMatching(existing, request)
+    assertFalse(result)
   }
 
   @ParameterizedTest
@@ -119,6 +157,7 @@ internal class SentenceComparatorTest {
       sentenceExpiryDate = randomDate(),
       sentenceLength = SentenceLength(Random.nextInt(), Random.nextInt(), Random.nextInt()),
       sentencingCourt = randomString("sentencingCourt"),
+      sentencedUnder = randomString("sentencedUnder"),
     )
     val request = CreateOrUpdateSentenceRequest(
       custodyType = differsOrTheSame(keyFieldToBeDifferent, "custodyType", existing.custodyType),
@@ -147,6 +186,7 @@ internal class SentenceComparatorTest {
       espCustodialPeriod = null,
       espExtendedPeriod = null,
       releaseDate = null,
+      sentencedUnder = differsOrTheSame(keyFieldToBeDifferent, "sentencedUnder", existing.sentencedUnder!!),
     )
     val result = comparator.areMatching(existing, request)
     assertFalse(result)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -41,7 +41,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomString
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomTimeToday
 import java.io.File
 import java.time.format.DateTimeFormatter
-import java.util.UUID
+import java.util.*
 import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.random.Random
@@ -147,8 +147,8 @@ abstract class IntegrationTestBase {
       sentenceLengthPartDays: Int = Random.nextInt(0, 20),
       sentencingCourt: String = randomString("sentCourt"),
       sentencedUnder: String = randomString(),
-    ): String {
-      return """ 
+    ) =
+      """ 
         {
           "custodyType":"$custodyType",
           "dateOfSentence":"$dateOfSentence",
@@ -172,8 +172,7 @@ abstract class IntegrationTestBase {
           "sentencingCourt":"$sentencingCourt",
           "sentencedUnder":"$sentencedUnder"
         }
-        """.trimIndent()
-    }
+      """.trimIndent()
 
     fun releaseRequestBody(
       dateOfRelease: String = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -146,29 +146,33 @@ abstract class IntegrationTestBase {
       sentenceLengthPartMonths: Int = Random.nextInt(0, 20),
       sentenceLengthPartDays: Int = Random.nextInt(0, 20),
       sentencingCourt: String = randomString("sentCourt"),
+      sentencedUnder: String = randomString(),
     ): String {
-      return "{" +
-        "\"custodyType\":\"$custodyType\", " +
-        "\"dateOfSentence\":\"$dateOfSentence\", " +
-        "\"espCustodialPeriod\":{" +
-        "  \"years\":\"$espCustodialPeriodYears\", " +
-        "  \"months\":\"$espCustodialPeriodMonths\" " +
-        "}," +
-        "\"espExtendedPeriod\":{" +
-        "  \"years\":\"$espExtendedPeriodYears\", " +
-        "  \"months\":\"$espExtendedPeriodMonths\" " +
-        "}," +
-        "\"licenceExpiryDate\":\"$licenceExpiryDate\", " +
-        "\"mappaLevel\":\"$mappaLevel\", " +
-        "\"releaseDate\":\"$releaseDate\", " +
-        "\"sentenceExpiryDate\":\"$sentenceExpiryDate\", " +
-        "\"sentenceLength\":{" +
-        "  \"partYears\":\"$sentenceLengthPartYears\", " +
-        "  \"partMonths\":\"$sentenceLengthPartMonths\", " +
-        "  \"partDays\":\"$sentenceLengthPartDays\" " +
-        "}," +
-        "\"sentencingCourt\":\"$sentencingCourt\" " +
-        "}"
+      return """ 
+        {
+          "custodyType":"$custodyType",
+          "dateOfSentence":"$dateOfSentence",
+          "espCustodialPeriod": {
+            "years":"$espCustodialPeriodYears",
+            "months":"$espCustodialPeriodMonths"
+          },
+          "espExtendedPeriod": {
+            "years":"$espExtendedPeriodYears",
+            "months":"$espExtendedPeriodMonths"
+          },
+          "licenceExpiryDate":"$licenceExpiryDate",
+          "mappaLevel":"$mappaLevel",
+          "releaseDate":"$releaseDate",
+          "sentenceExpiryDate":"$sentenceExpiryDate",
+          "sentenceLength": {
+            "partYears":"$sentenceLengthPartYears",
+            "partMonths":"$sentenceLengthPartMonths",
+            "partDays":"$sentenceLengthPartDays"
+          },
+          "sentencingCourt":"$sentencingCourt",
+          "sentencedUnder":"$sentencedUnder"
+        }
+        """.trimIndent()
     }
 
     fun releaseRequestBody(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
@@ -73,11 +73,15 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
   @Test
   fun `given missing optional fields in request body when create offender called then 201 created is returned`() {
     val offenderId = createTestOffenderInPpud()
-    val requestBodyWithOnlyMandatoryFields = "{" +
-      "\"custodyType\":\"$PPUD_VALID_CUSTODY_TYPE\", " +
-      "\"dateOfSentence\":\"${randomDate()}\", " +
-      "\"mappaLevel\":\"$PPUD_VALID_MAPPA_LEVEL\" " +
-      "}"
+    val requestBodyWithOnlyMandatoryFields =
+      """
+        {
+          "custodyType":"$PPUD_VALID_CUSTODY_TYPE",
+          "dateOfSentence":"${randomDate()}",
+          "mappaLevel":"$PPUD_VALID_MAPPA_LEVEL",
+          "sentencedUnder":"$PPUD_VALID_SENTENCED_UNDER"
+        }
+      """.trimIndent()
 
     postSentence(offenderId, requestBodyWithOnlyMandatoryFields)
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.integration.Mandatory
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_CUSTODY_TYPE
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_MAPPA_LEVEL
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_MAPPA_LEVEL_2
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_SENTENCED_UNDER
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomDate
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomPpudId
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomString
@@ -129,6 +130,7 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
     val espExtendedPeriodMonths = Random.nextInt(0, 1000)
     val licenceExpiryDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentencingCourt = randomString("sentCourt")
+    val sentencedUnder = PPUD_VALID_SENTENCED_UNDER
     val releaseDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentenceExpiryDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentenceLengthPartYears = Random.nextInt(0, 1000)
@@ -146,6 +148,7 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
       releaseDate = releaseDate,
       sentenceExpiryDate = sentenceExpiryDate,
       sentencingCourt = sentencingCourt,
+      sentencedUnder = sentencedUnder,
       sentenceLengthPartYears = sentenceLengthPartYears,
       sentenceLengthPartMonths = sentenceLengthPartMonths,
       sentenceLengthPartDays = sentenceLengthPartDays,
@@ -166,7 +169,7 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
       .jsonPath("offender.sentences[1].licenceExpiryDate").isEqualTo(licenceExpiryDate)
       .jsonPath("offender.sentences[1].mappaLevel").isEqualTo(PPUD_VALID_MAPPA_LEVEL_2)
       .jsonPath("offender.sentences[1].releaseDate").isEqualTo(releaseDate)
-      .jsonPath("offender.sentences[1].sentencedUnder").isEqualTo("Not Specified")
+      .jsonPath("offender.sentences[1].sentencedUnder").isEqualTo(sentencedUnder)
       .jsonPath("offender.sentences[1].sentenceExpiryDate").isEqualTo(sentenceExpiryDate)
       .jsonPath("offender.sentences[1].sentenceLength.partYears").isEqualTo(sentenceLengthPartYears)
       .jsonPath("offender.sentences[1].sentenceLength.partMonths").isEqualTo(sentenceLengthPartMonths)
@@ -184,6 +187,7 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
     val espExtendedPeriodMonths = Random.nextInt(0, 1000)
     val licenceExpiryDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentencingCourt = randomString("sentCourt")
+    val sentencedUnder = PPUD_VALID_SENTENCED_UNDER
     val releaseDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentenceExpiryDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentenceLengthPartYears = Random.nextInt(0, 1000)
@@ -201,6 +205,7 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
       releaseDate = releaseDate,
       sentenceExpiryDate = sentenceExpiryDate,
       sentencingCourt = sentencingCourt,
+      sentencedUnder = sentencedUnder,
       sentenceLengthPartYears = sentenceLengthPartYears,
       sentenceLengthPartMonths = sentenceLengthPartMonths,
       sentenceLengthPartDays = sentenceLengthPartDays,
@@ -223,7 +228,7 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
       .jsonPath("offender.sentences[1].licenceExpiryDate").isEqualTo(licenceExpiryDate)
       .jsonPath("offender.sentences[1].mappaLevel").isEqualTo(PPUD_VALID_MAPPA_LEVEL_2)
       .jsonPath("offender.sentences[1].releaseDate").isEqualTo(releaseDate)
-      .jsonPath("offender.sentences[1].sentencedUnder").isEqualTo("Not Specified")
+      .jsonPath("offender.sentences[1].sentencedUnder").isEqualTo(sentencedUnder)
       .jsonPath("offender.sentences[1].sentenceExpiryDate").isEqualTo(sentenceExpiryDate)
       .jsonPath("offender.sentences[1].sentenceLength.partYears").isEqualTo(sentenceLengthPartYears)
       .jsonPath("offender.sentences[1].sentenceLength.partMonths").isEqualTo(sentenceLengthPartMonths)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceUpdateTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.integration.Mandatory
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_CUSTODY_TYPE
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_MAPPA_LEVEL
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_MAPPA_LEVEL_2
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_SENTENCED_UNDER
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomDate
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomPpudId
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomString
@@ -124,6 +125,7 @@ class OffenderSentenceUpdateTest : IntegrationTestBase() {
     val espExtendedPeriodMonths = Random.nextInt(0, 1000)
     val licenceExpiryDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentencingCourt = randomString("sentCourt")
+    val sentencedUnder = PPUD_VALID_SENTENCED_UNDER
     val releaseDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentenceExpiryDate = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val sentenceLengthPartYears = Random.nextInt(0, 1000)
@@ -141,6 +143,7 @@ class OffenderSentenceUpdateTest : IntegrationTestBase() {
       releaseDate = releaseDate,
       sentenceExpiryDate = sentenceExpiryDate,
       sentencingCourt = sentencingCourt,
+      sentencedUnder = sentencedUnder,
       sentenceLengthPartYears = sentenceLengthPartYears,
       sentenceLengthPartMonths = sentenceLengthPartMonths,
       sentenceLengthPartDays = sentenceLengthPartDays,
@@ -161,7 +164,7 @@ class OffenderSentenceUpdateTest : IntegrationTestBase() {
       .jsonPath("offender.sentences[0].licenceExpiryDate").isEqualTo(licenceExpiryDate)
       .jsonPath("offender.sentences[0].mappaLevel").isEqualTo(PPUD_VALID_MAPPA_LEVEL_2)
       .jsonPath("offender.sentences[0].releaseDate").isEqualTo(releaseDate)
-      .jsonPath("offender.sentences[0].sentencedUnder").isEqualTo("Not Specified")
+      .jsonPath("offender.sentences[0].sentencedUnder").isEqualTo(sentencedUnder)
       .jsonPath("offender.sentences[0].sentenceExpiryDate").isEqualTo(sentenceExpiryDate)
       .jsonPath("offender.sentences[0].sentenceLength.partYears").isEqualTo(sentenceLengthPartYears)
       .jsonPath("offender.sentences[0].sentenceLength.partMonths").isEqualTo(sentenceLengthPartMonths)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceUpdateTest.kt
@@ -80,11 +80,15 @@ class OffenderSentenceUpdateTest : IntegrationTestBase() {
 
   @Test
   fun `given missing optional fields in request body when update sentence called then 200 OK is returned`() {
-    val requestBodyWithOnlyMandatoryFields = "{" +
-      "\"custodyType\":\"$PPUD_VALID_CUSTODY_TYPE\", " +
-      "\"dateOfSentence\":\"${randomDate()}\", " +
-      "\"mappaLevel\":\"$PPUD_VALID_MAPPA_LEVEL\" " +
-      "}"
+    val requestBodyWithOnlyMandatoryFields =
+      """
+        {
+          "custodyType":"$PPUD_VALID_CUSTODY_TYPE",
+          "dateOfSentence":"${randomDate()}",
+          "mappaLevel":"$PPUD_VALID_MAPPA_LEVEL",
+          "sentencedUnder":"$PPUD_VALID_SENTENCED_UNDER"
+        }
+      """.trimIndent()
 
     putSentence(offenderId, sentenceId, requestBodyWithOnlyMandatoryFields)
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
@@ -57,6 +57,8 @@ const val PPUD_VALID_RELEASED_UNDER = "CJA 1991"
 
 const val PPUD_VALID_RELEASED_UNDER_2 = "CJA 2008"
 
+const val PPUD_VALID_SENTENCED_UNDER = PPUD_VALID_RELEASED_UNDER
+
 const val PPUD_VALID_USER_FULL_NAME = "Consider a Recall Test Admin"
 
 const val PPUD_VALID_USER_TEAM = "Performance Management"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
@@ -274,6 +274,7 @@ fun generateCreateOrUpdateSentenceRequest(
   dateOfSentence: LocalDate = randomDate(),
   mappaLevel: String = randomString("mappaLevel"),
   sentencingCourt: String = randomString("sentencingCourt"),
+  sentencedUnder: String = randomString("sentencedUnder"),
 ): CreateOrUpdateSentenceRequest {
   return CreateOrUpdateSentenceRequest(
     custodyType = custodyType,
@@ -286,6 +287,7 @@ fun generateCreateOrUpdateSentenceRequest(
     sentenceExpiryDate = null,
     sentenceLength = null,
     sentencingCourt = sentencingCourt,
+    sentencedUnder = sentencedUnder,
   )
 }
 


### PR DESCRIPTION
Support for setting a Sentence's 'Sentenced Under' field is added here. The new
field is mandatory, in line with how the 'Released Under' field for Releases is
mandatory, as both these fields should refer to the same legislation when the
Release falls under the Sentence.

The new sentencedUnder field is included here in the SentenceComparator's
logic. Although the reason behind the exclusion of some of the Sentence's
fields from the comparison is unclear, the new field was included, as:
 - Most of the existing fields have been included so far.
 - We see no reason why two sentences with different sentencedUnder values
   should be considered to be the same.