### PR TITLE
MRD-2639 Support offender establishment

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/offender/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/offender/Offender.kt
@@ -14,6 +14,7 @@ data class Offender(
   val firstNames: String,
   val gender: String,
   val immigrationStatus: String,
+  val establishment: String,
   val isInCustody: Boolean,
   val nomsId: String,
   val prisonerCategory: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateOffenderRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/CreateOffenderRequest.kt
@@ -30,6 +30,7 @@ class CreateOffenderRequest(
   nomsId: String? = null,
   @field:NotBlank
   val prisonNumber: String,
+  val establishment: String,
 ) {
   val croNumber: String = croNumber ?: ""
   val nomsId: String = nomsId ?: ""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/UpdateOffenderRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/request/UpdateOffenderRequest.kt
@@ -21,6 +21,7 @@ class UpdateOffenderRequest(
   nomsId: String? = null,
   @field:NotBlank
   val prisonNumber: String,
+  val establishment: String,
 ) {
   val croNumber: String = croNumber ?: ""
   val nomsId: String = nomsId ?: ""

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/NewOffenderPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/NewOffenderPage.kt
@@ -110,6 +110,12 @@ internal class NewOffenderPage(
   @FindBy(id = "content_ddliYOUNG_OFFENDER")
   private lateinit var youngOffenderDropdown: WebElement
 
+  @FindBy(id = "content_aceCURRENT_ESTABLISHMENT_AutoCompleteTextBox")
+  private lateinit var currentEstablishmentInput: WebElement
+
+  @FindBy(id = "content_aceCURRENT_ESTABLISHMENT_AutoSelect")
+  private lateinit var currentEstablishmentDropdown: WebElement
+
   init {
     PageFactory.initElements(driver, this)
   }
@@ -121,9 +127,20 @@ internal class NewOffenderPage(
   }
 
   suspend fun createOffender(createOffenderRequest: CreateOffenderRequest) {
-    // Complete these first as they trigger additional processing
+    // The index offence and establishment fields are autocomplete fields. After inputting
+    // values, a dropdown is loaded with the options that satisfy the input text, from which
+    // the final value must be selected. The dropdown can take a bit of time to show up, so
+    // we input the values at the start of the process and select the options from the dropdowns
+    // later on, to minimise the chance of the dropdown not being loaded by the time the code
+    // tries to pick the option
     indexOffenceInput.click()
     indexOffenceInput.sendKeys(createOffenderRequest.indexOffence)
+    currentEstablishmentInput.click()
+    currentEstablishmentInput.sendKeys(createOffenderRequest.establishment)
+
+    // The MAPPA level field is reset every time the custody type one has its value changes (or
+    // at least when setting it to Determinate; I didn't test every option), so we make sure we
+    // set this early on before setting the MAPPA level
     pageHelper.selectDropdownOptionIfNotBlank(custodyTypeDropdown, createOffenderRequest.custodyType, "custody type")
 
     // Complete standalone fields
@@ -147,9 +164,14 @@ internal class NewOffenderPage(
       pageHelper.selectDropdownOptionIfNotBlank(youngOffenderDropdown, youngOffenderYes, "young offender")
     }
 
-    // Complete fields that have been updated/refreshed.
+    // See comments further up regarding these three fields
     pageHelper.selectDropdownOptionIfNotBlank(indexOffenceDropdown, createOffenderRequest.indexOffence, "index offence")
     pageHelper.selectDropdownOptionIfNotBlank(mappaLevelDropdown, createOffenderRequest.mappaLevel, "mappa level")
+    pageHelper.selectDropdownOptionIfNotBlank(
+      currentEstablishmentDropdown,
+      createOffenderRequest.establishment,
+      "establishment",
+    )
 
     saveButton.click()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -22,6 +22,8 @@ import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.helpers.ValueConsumer
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_CUSTODY_TYPE
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ESTABLISHMENT
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ETHNICITY
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_GENDER
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_INDEX_OFFENCE
@@ -82,23 +84,27 @@ abstract class IntegrationTestBase {
       mappaLevel: String = PPUD_VALID_MAPPA_LEVEL,
       nomsId: String = "",
       prisonNumber: String = randomPrisonNumber(),
-    ): String = "{" +
-      "\"address\":$address, " +
-      "\"additionalAddresses\":[$additionalAddresses], " +
-      "\"croNumber\":\"$croNumber\", " +
-      "\"custodyType\":\"$custodyType\", " +
-      "\"dateOfBirth\":\"$dateOfBirth\", " +
-      "\"dateOfSentence\":\"$dateOfSentence\", " +
-      "\"ethnicity\":\"$ethnicity\", " +
-      "\"familyName\":\"$familyName\", " +
-      "\"firstNames\":\"$firstNames\", " +
-      "\"gender\":\"$gender\", " +
-      "\"indexOffence\":\"$indexOffence\", " +
-      "\"isInCustody\":\"$isInCustody\", " +
-      "\"mappaLevel\":\"$mappaLevel\", " +
-      "\"nomsId\":\"$nomsId\", " +
-      "\"prisonNumber\":\"$prisonNumber\" " +
-      "}"
+      establishment: String = PPUD_VALID_ESTABLISHMENT,
+    ): String = """  
+      {
+        "address" : $address,
+        "additionalAddresses" : [$additionalAddresses],
+        "croNumber" : "$croNumber",
+        "custodyType" : "$custodyType",
+        "dateOfBirth" : "$dateOfBirth",
+        "dateOfSentence" : "$dateOfSentence",
+        "ethnicity" : "$ethnicity",
+        "familyName" : "$familyName",
+        "firstNames" : "$firstNames",
+        "gender" : "$gender",
+        "indexOffence" : "$indexOffence",
+        "isInCustody" : "$isInCustody",
+        "mappaLevel" : "$mappaLevel",
+        "nomsId" : "$nomsId",
+        "prisonNumber" : "$prisonNumber",
+        "establishment" : "$establishment"
+      }
+    """.trimIndent()
 
     fun updateOffenderRequestBody(
       address: String = addressRequestBody(),
@@ -112,19 +118,24 @@ abstract class IntegrationTestBase {
       isInCustody: String = "false",
       nomsId: String = "",
       prisonNumber: String = randomPrisonNumber(),
-    ): String = "{" +
-      "\"address\":$address, " +
-      "\"additionalAddresses\":[$additionalAddresses], " +
-      "\"croNumber\":\"$croNumber\", " +
-      "\"dateOfBirth\":\"$dateOfBirth\", " +
-      "\"ethnicity\":\"$ethnicity\", " +
-      "\"familyName\":\"$familyName\", " +
-      "\"firstNames\":\"$firstNames\", " +
-      "\"gender\":\"$gender\", " +
-      "\"isInCustody\":\"$isInCustody\", " +
-      "\"nomsId\":\"$nomsId\", " +
-      "\"prisonNumber\":\"$prisonNumber\" " +
-      "}"
+      establishment: String = PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE,
+    ): String =
+      """
+        {
+          "address" : $address,
+          "additionalAddresses" : [$additionalAddresses],
+          "croNumber" : "$croNumber",
+          "dateOfBirth" : "$dateOfBirth",
+          "ethnicity" : "$ethnicity",
+          "familyName" : "$familyName",
+          "firstNames" : "$firstNames",
+          "gender" : "$gender",
+          "isInCustody" : "$isInCustody",
+          "nomsId" : "$nomsId",
+          "prisonNumber" : "$prisonNumber",
+          "establishment" : "$establishment"
+        }
+      """.trimIndent()
 
     fun createOrUpdateSentenceRequestBody(
       custodyType: String = PPUD_VALID_CUSTODY_TYPE,
@@ -233,12 +244,13 @@ abstract class IntegrationTestBase {
     fun ppudUserRequestBody(
       fullName: String = PPUD_VALID_USER_FULL_NAME,
       teamName: String = PPUD_VALID_USER_TEAM,
-    ): String = """
+    ): String =
+      """
         {
           "fullName":"$fullName",
           "teamName":"$teamName"
         }
-    """.trimIndent()
+      """.trimIndent()
 
     fun addressRequestBody(
       premises: String = randomString("premises"),
@@ -246,13 +258,16 @@ abstract class IntegrationTestBase {
       line2: String = randomString("line2"),
       postcode: String = randomString("postcode"),
       phoneNumber: String = randomString("phoneNumber"),
-    ): String = "{" +
-      "\"premises\":\"$premises\", " +
-      "\"line1\":\"$line1\", " +
-      "\"line2\":\"$line2\", " +
-      "\"postcode\":\"$postcode\", " +
-      "\"phoneNumber\":\"$phoneNumber\" " +
-      "}"
+    ): String =
+      """
+        {
+          "premises" : "$premises",
+          "line1" : "$line1",
+          "line2" : "$line2",
+          "postcode" : "$postcode",
+          "phoneNumber" : "$phoneNumber"
+        }
+      """.trimIndent()
   }
 
   @BeforeAll

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderCreateTest.kt
@@ -20,6 +20,8 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_IMMIGRA
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_PRISONER_CATEGORY
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_STATUS
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_CUSTODY_TYPE
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ESTABLISHMENT
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ETHNICITY
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_GENDER
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_INDEX_OFFENCE
@@ -103,18 +105,22 @@ class OffenderCreateTest : IntegrationTestBase() {
 
   @Test
   fun `given missing optional fields in request body when create offender called then 201 created is returned`() {
-    val requestBodyWithOnlyMandatoryFields = "{" +
-      "\"custodyType\":\"$PPUD_VALID_CUSTODY_TYPE\", " +
-      "\"dateOfBirth\":\"${randomDate()}\", " +
-      "\"dateOfSentence\":\"${randomDate()}\", " +
-      "\"ethnicity\":\"$PPUD_VALID_ETHNICITY\", " +
-      "\"familyName\":\"$FAMILY_NAME_PREFIX-$testRunId\", " +
-      "\"firstNames\":\"${randomString("firstNames")}\", " +
-      "\"gender\":\"$PPUD_VALID_GENDER\", " +
-      "\"indexOffence\":\"$PPUD_VALID_INDEX_OFFENCE\", " +
-      "\"mappaLevel\":\"$PPUD_VALID_MAPPA_LEVEL\", " +
-      "\"prisonNumber\":\"${randomPrisonNumber()}\" " +
-      "}"
+    val requestBodyWithOnlyMandatoryFields =
+      """
+        {
+          "custodyType" : "$PPUD_VALID_CUSTODY_TYPE",
+          "dateOfBirth" : "${randomDate()}",
+          "dateOfSentence" : "${randomDate()}",
+          "ethnicity" : "$PPUD_VALID_ETHNICITY",
+          "familyName" : "$FAMILY_NAME_PREFIX-$testRunId",
+          "firstNames" : "${randomString("firstNames")}",
+          "gender" : "$PPUD_VALID_GENDER",
+          "indexOffence" : "$PPUD_VALID_INDEX_OFFENCE",
+          "mappaLevel" : "$PPUD_VALID_MAPPA_LEVEL",
+          "prisonNumber" : "${randomPrisonNumber()}",
+          "establishment" : "$PPUD_VALID_ESTABLISHMENT"
+        }
+      """.trimIndent()
 
     postOffender(requestBodyWithOnlyMandatoryFields)
       .expectStatus()
@@ -123,27 +129,31 @@ class OffenderCreateTest : IntegrationTestBase() {
 
   @Test
   fun `given null optional string fields in request body when create offender called then nulls are treated as empty strings`() {
-    val requestBodyWithNullOptionalFields = "{" +
-      "\"address\": {" +
-      "\"premises\":null, " +
-      "\"line1\":null, " +
-      "\"line2\":null, " +
-      "\"postcode\":null, " +
-      "\"phoneNumber\":null " +
-      "}, " +
-      "\"custodyType\":\"$PPUD_VALID_CUSTODY_TYPE\", " +
-      "\"croNumber\":null, " +
-      "\"dateOfBirth\":\"${randomDate()}\", " +
-      "\"dateOfSentence\":\"${randomDate()}\", " +
-      "\"ethnicity\":\"$PPUD_VALID_ETHNICITY\", " +
-      "\"familyName\":\"$FAMILY_NAME_PREFIX-$testRunId\", " +
-      "\"firstNames\":\"${randomString("firstNames")}\", " +
-      "\"gender\":\"$PPUD_VALID_GENDER\", " +
-      "\"indexOffence\":\"$PPUD_VALID_INDEX_OFFENCE\", " +
-      "\"mappaLevel\":\"$PPUD_VALID_MAPPA_LEVEL\", " +
-      "\"nomsId\":null, " +
-      "\"prisonNumber\":\"${randomPrisonNumber()}\" " +
-      "}"
+    val requestBodyWithNullOptionalFields =
+      """ 
+      {
+        "address" : {
+          "premises" : null,
+          "line1" : null,
+          "line2" : null,
+          "postcode" : null,
+          "phoneNumber" : null
+        },
+        "custodyType" : "$PPUD_VALID_CUSTODY_TYPE",
+        "croNumber" : null,
+        "dateOfBirth" : "${randomDate()}",
+        "dateOfSentence" : "${randomDate()}",
+        "ethnicity" : "$PPUD_VALID_ETHNICITY",
+        "familyName" : "$FAMILY_NAME_PREFIX-$testRunId",
+        "firstNames" : "${randomString("firstNames")}",
+        "gender" : "$PPUD_VALID_GENDER",
+        "indexOffence" : "$PPUD_VALID_INDEX_OFFENCE",
+        "mappaLevel" : "$PPUD_VALID_MAPPA_LEVEL",
+        "nomsId" : null,
+        "prisonNumber" : "${randomPrisonNumber()}",
+        "establishment" : "$PPUD_VALID_ESTABLISHMENT"
+      }
+      """.trimIndent()
 
     val createdOffender = testPostOffender(requestBodyWithNullOptionalFields)
 
@@ -186,9 +196,10 @@ class OffenderCreateTest : IntegrationTestBase() {
     val dateOfSentence = randomDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
     val familyName = "$FAMILY_NAME_PREFIX-$testRunId"
     val firstNames = randomString("firstNames")
-    val isInCustody = Random.nextBoolean().toString()
+    val isInCustody = Random.nextBoolean()
     val nomsId = randomNomsId()
     val prisonNumber = randomPrisonNumber()
+    val establishment = if (isInCustody) PPUD_VALID_ESTABLISHMENT else PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE
     val requestBody = createOffenderRequestBody(
       address = addressRequestBody(addressPremises, addressLine1, addressLine2, addressPostcode, addressPhoneNumber),
       additionalAddresses = addressRequestBody(
@@ -207,10 +218,11 @@ class OffenderCreateTest : IntegrationTestBase() {
       firstNames = firstNames,
       gender = PPUD_VALID_GENDER,
       indexOffence = PPUD_VALID_INDEX_OFFENCE,
-      isInCustody = isInCustody,
+      isInCustody = isInCustody.toString(),
       mappaLevel = PPUD_VALID_MAPPA_LEVEL,
       nomsId = nomsId,
       prisonNumber = prisonNumber,
+      establishment = establishment,
     )
 
     val createdOffender = testPostOffender(requestBody)
@@ -233,7 +245,7 @@ class OffenderCreateTest : IntegrationTestBase() {
       .jsonPath("offender.firstNames").isEqualTo(firstNames)
       .jsonPath("offender.gender").isEqualTo(PPUD_VALID_GENDER)
       .jsonPath("offender.immigrationStatus").isEqualTo(PPUD_IMMIGRATION_STATUS)
-      .jsonPath("offender.isInCustody").isEqualTo(isInCustody)
+      .jsonPath("offender.isInCustody").isEqualTo(isInCustody.toString())
       .jsonPath("offender.nomsId").isEqualTo(nomsId)
       .jsonPath("offender.prisonerCategory").isEqualTo(PPUD_PRISONER_CATEGORY)
       .jsonPath("offender.prisonNumber").isEqualTo(prisonNumber)
@@ -244,6 +256,7 @@ class OffenderCreateTest : IntegrationTestBase() {
       .jsonPath("offender.sentences[0].dateOfSentence").isEqualTo(dateOfSentence)
       .jsonPath("offender.sentences[0].mappaLevel").isEqualTo(PPUD_VALID_MAPPA_LEVEL)
       .jsonPath("offender.sentences[0].offence.indexOffence").isEqualTo(PPUD_VALID_INDEX_OFFENCE)
+      .jsonPath("offender.establishment").isEqualTo(establishment)
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderUpdateTest.kt
@@ -14,6 +14,9 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.integration.Mandatory
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_IMMIGRATION_STATUS
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_PRISONER_CATEGORY
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_STATUS
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ESTABLISHMENT
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ESTABLISHMENT_2
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ETHNICITY
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_ETHNICITY_2
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_GENDER
@@ -105,14 +108,18 @@ class OffenderUpdateTest : IntegrationTestBase() {
 
   @Test
   fun `given missing optional fields in request body when update offender called then 200 ok is returned`() {
-    val requestBodyWithOnlyMandatoryFields = "{" +
-      "\"dateOfBirth\":\"${randomDate()}\", " +
-      "\"ethnicity\":\"$PPUD_VALID_ETHNICITY\", " +
-      "\"familyName\":\"${FAMILY_NAME_PREFIX}-${testRunId}\", " +
-      "\"firstNames\":\"${randomString("firstNames")}\", " +
-      "\"gender\":\"$PPUD_VALID_GENDER\", " +
-      "\"prisonNumber\":\"${randomPrisonNumber()}\" " +
-      "}"
+    val requestBodyWithOnlyMandatoryFields =
+      """
+        {
+          "dateOfBirth" : "${randomDate()}",
+          "ethnicity" : "$PPUD_VALID_ETHNICITY",
+          "familyName" : "$FAMILY_NAME_PREFIX-$testRunId",
+          "firstNames" : "${randomString("firstNames")}",
+          "gender" : "$PPUD_VALID_GENDER",
+          "prisonNumber" : "${randomPrisonNumber()}",
+          "establishment" : "$PPUD_VALID_ESTABLISHMENT"
+        }
+      """.trimIndent()
 
     putOffender(testOffenderId, requestBodyWithOnlyMandatoryFields)
       .expectStatus()
@@ -121,16 +128,20 @@ class OffenderUpdateTest : IntegrationTestBase() {
 
   @Test
   fun `given null optional string fields in request body when update offender called then nulls are treated as empty string`() {
-    val requestBodyWithNullOptionalFields = "{" +
-      "\"croNumber\":null, " +
-      "\"dateOfBirth\":\"${randomDate()}\", " +
-      "\"ethnicity\":\"$PPUD_VALID_ETHNICITY\", " +
-      "\"familyName\":\"${FAMILY_NAME_PREFIX}-${testRunId}\", " +
-      "\"firstNames\":\"${randomString("firstNames")}\", " +
-      "\"gender\":\"$PPUD_VALID_GENDER\", " +
-      "\"nomsId\":null, " +
-      "\"prisonNumber\":\"${randomPrisonNumber()}\" " +
-      "}"
+    val requestBodyWithNullOptionalFields =
+      """
+        {
+          "croNumber" : null,
+          "dateOfBirth" : "${randomDate()}",
+          "ethnicity" : "$PPUD_VALID_ETHNICITY",
+          "familyName" : "$FAMILY_NAME_PREFIX-$testRunId",
+          "firstNames" : "${randomString("firstNames")}",
+          "gender" : "$PPUD_VALID_GENDER",
+          "nomsId" : null,
+          "prisonNumber" : "${randomPrisonNumber()}",
+          "establishment" : "$PPUD_VALID_ESTABLISHMENT"
+        }
+      """.trimIndent()
 
     putOffender(testOffenderId, requestBodyWithNullOptionalFields)
       .expectStatus()
@@ -167,6 +178,7 @@ class OffenderUpdateTest : IntegrationTestBase() {
       createOffenderRequestBody(
         additionalAddresses = addressRequestBody(originalAdditionalAddressPremises, "", "", "", ""),
         isInCustody = originalIsInCustody.toString(),
+        establishment = if (originalIsInCustody) PPUD_VALID_ESTABLISHMENT else PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE,
       ),
     )
     val amendUuid = UUID.randomUUID()
@@ -189,6 +201,7 @@ class OffenderUpdateTest : IntegrationTestBase() {
     val gender = PPUD_VALID_GENDER_2
     val nomsId = randomNomsId()
     val prisonNumber = randomPrisonNumber()
+    val establishment = if (newIsInCustody) PPUD_VALID_ESTABLISHMENT_2 else PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE
     val requestBody = updateOffenderRequestBody(
       address = addressRequestBody(addressPremises, addressLine1, addressLine2, addressPostcode, addressPhoneNumber),
       additionalAddresses = addressRequestBody(
@@ -207,6 +220,7 @@ class OffenderUpdateTest : IntegrationTestBase() {
       isInCustody = newIsInCustody.toString(),
       nomsId = nomsId,
       prisonNumber = prisonNumber,
+      establishment = establishment,
     )
 
     putOffender(localTestOffenderId, requestBody)
@@ -237,6 +251,7 @@ class OffenderUpdateTest : IntegrationTestBase() {
       .jsonPath("offender.nomsId").isEqualTo(nomsId)
       .jsonPath("offender.prisonerCategory").isEqualTo(PPUD_PRISONER_CATEGORY)
       .jsonPath("offender.prisonNumber").isEqualTo(prisonNumber)
+      .jsonPath("offender.establishment").isEqualTo(establishment)
       .jsonPath("offender.status").isEqualTo(PPUD_STATUS)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/testdata/TestValues.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata
 
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.DocumentCategory
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.PpudUser
-import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.RiskOfSeriousHarmLevel
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.Offender
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.OffenderAddress
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.SearchResultOffender
@@ -64,6 +63,12 @@ const val PPUD_VALID_USER_FULL_NAME = "Consider a Recall Test Admin"
 const val PPUD_VALID_USER_TEAM = "Performance Management"
 
 const val PPUD_IMMIGRATION_STATUS = "Not Applicable"
+
+const val PPUD_VALID_ESTABLISHMENT = "Hartington Wing"
+
+const val PPUD_VALID_ESTABLISHMENT_2 = "Winterbourne View"
+
+const val PPUD_VALID_ESTABLISHMENT_NOT_APPLICABLE = "Not Applicable"
 
 const val PPUD_LICENCE_TYPE = "Standard"
 
@@ -157,8 +162,6 @@ fun randomPpudId(): String {
 
 fun randomLookupName(exclude: List<LookupName> = listOf()): LookupName = LookupName.entries.filter { exclude.contains(it).not() }.shuffled().first()
 
-fun randomRiskOfSeriousHarmLevel(): RiskOfSeriousHarmLevel = RiskOfSeriousHarmLevel.entries.shuffled().first()
-
 fun randomDocumentCategory(exclude: DocumentCategory? = null): DocumentCategory = DocumentCategory.entries.shuffled().first { it != exclude }
 
 /**
@@ -180,6 +183,7 @@ fun generateCreateOffenderRequest(): CreateOffenderRequest = CreateOffenderReque
   mappaLevel = randomString("mappaLevel"),
   nomsId = randomNomsId(),
   prisonNumber = randomPrisonNumber(),
+  establishment = randomString("establishment"),
 )
 
 /**
@@ -195,6 +199,7 @@ fun generateUpdateOffenderRequest(): UpdateOffenderRequest = UpdateOffenderReque
   gender = randomString("gender"),
   isInCustody = Random.nextBoolean(),
   prisonNumber = randomPrisonNumber(),
+  establishment = randomString("establishment"),
 )
 
 fun generateOffender(id: String = randomPpudId()): Offender {
@@ -211,6 +216,7 @@ fun generateOffender(id: String = randomPpudId()): Offender {
     firstNames = randomString("firstNames"),
     gender = randomString("gender"),
     immigrationStatus = randomString("immigrationStatus"),
+    establishment = randomString("establishment"),
     isInCustody = Random.nextBoolean(),
     nomsId = randomNomsId(),
     prisonerCategory = randomString("prisonerCategory"),
@@ -304,7 +310,6 @@ fun generateCreateRecallRequest(
   receivedDateTime: LocalDateTime = randomTimeToday(),
   recommendedTo: PpudUser = generatePpudUser(),
   riskOfContrabandDetails: String? = null,
-  riskOfSeriousHarmLevel: RiskOfSeriousHarmLevel? = null,
 ): CreateRecallRequest = CreateRecallRequest(
   decisionDateTime = randomTimeToday(),
   isExtendedSentence = isExtendedSentence ?: Random.nextBoolean(),


### PR DESCRIPTION
When a PPCS user books an offender into PPUD, they fill in the offender's
current establishment. At the moment, this happens manually, but it is going to
be incorporated into the CaR journey, so we need to make these changes here so
the establishment can be set automatically.