### PR TITLE
Update AppInsights connection string

### DIFF
--- a/helm_deploy/hmpps-ppud-automation-api/values.yaml
+++ b/helm_deploy/hmpps-ppud-automation-api/values.yaml
@@ -30,7 +30,7 @@ generic-service:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
-    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
+    APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     SPRING_DATA_REDIS_SSL_ENABLED: "true"
     CACHE_TIMETOLIVESECONDS: 43200  # 12 hours


### PR DESCRIPTION
An issue was found where AppInsights produces repeated log warnings regarding an "Unsupported text Content-Type Type". Although it has been fixed in a later version of AppInsights, Microsoft indicated they still recommend the connection string include the Ingestion and Live Endpoints, so they are added here. See https://github:com/ministryofjustice/dps-gradle-spring-boot/pull/357/files for more details.