### PR TITLE
MRD-2712 Add OpenApiDocsTest

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/OpenApiDocsTest.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.integration
+
+import io.swagger.v3.parser.OpenAPIV3Parser
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class OpenApiDocsTest {
+
+  @Autowired
+  private lateinit var webTestClient: WebTestClient
+
+  @LocalServerPort
+  private var port: Int = 0
+
+  @Test
+  fun `open api docs are available`() {
+    webTestClient.get()
+      .uri("/swagger-ui/index.html?configUrl=/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `open api docs redirect to correct page`() {
+    webTestClient.get()
+      .uri("/swagger-ui.html")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().is3xxRedirection
+      .expectHeader().value("Location") { it.contains("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config") }
+  }
+
+  @Test
+  fun `the open api json contains documentation`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("paths").isNotEmpty
+  }
+
+  @Test
+  fun `the open api json is valid and contains documentation`() {
+    val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
+    assertThat(result.messages).isEmpty()
+    assertThat(result.openAPI.paths).isNotEmpty
+  }
+
+  @Test
+  fun `the swagger json contains the version number`() {
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("info.version").isEqualTo(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
+  }
+
+  /* TODO: figure out if this is something we need to add or not
+  @Test
+  fun `the security scheme is setup for bearer tokens`() {
+    val bearerJwts = JSONArray()
+    bearerJwts.addAll(listOf("read", "write"))
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.bearer-jwt.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.bearer-jwt.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.bearer-jwt.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.security[0].bearer-jwt")
+      .isEqualTo(bearerJwts)
+  }
+   */
+}


### PR DESCRIPTION
Following on a conversation regarding an upgrade after which the Swagger UI
page stopped working in another project, it was highlighted that an automated
test can and should be set up to ensure this doesn't happen when changes are
made. The test added here is based on the one in
hmpps-prisoner-from-nomis-migration.

It is unclear at the moment whether the bearer token part is needed, so the
test has been commented out and will be either uncommented or removed in a
follow-up.