### PR TITLE
Address CVE-2025-22235, CVE-2025-27820, CVE-2025-22234

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.0.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
   kotlin("plugin.spring") version "2.1.10"
   id("org.sonarqube") version "6.0.1.5171"
   id("jacoco")
@@ -23,7 +23,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("org.seleniumhq.selenium:selenium-java:4.29.0")
-  implementation("io.github.bonigarcia:webdrivermanager:5.9.3")
+  implementation("io.github.bonigarcia:webdrivermanager:6.1.0")
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")


### PR DESCRIPTION
Two upgrades are needed to fix the mentioned CVEs:
 - The HMPPS Spring Boot plug-in is upgraded to 8.1.0, which includes Spring
   Boot 3.4.5, which includes Spring Security 6.4.5. This addresses CVEs
   https://github.com/advisories/GHSA-rc42-6c7j-7h5r and CVE-2025-22234
 - The Web Driver Manager is upgraded to 6.1.0, which, together with the Spring
   Boot upgrade, pulls in Apache HttpClient 5.4.3, as required to address
   https://github.com/advisories/GHSA-73m2-qfq3-56cx.

Note the Web Driver Manager upgrade involves a major upgrade, but from what I
see in the release notes the only potential breaking changes involve increases
to docker memory and recording resolution, as well as changing or removing
support for images or browsers other than Firefox (which we use to run
Selenium):
https://github.com/bonigarcia/webdrivermanager/blob/master/CHANGELOG.md