### PR TITLE
Run CircleCI validation from known IP range

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ executors:
 
 jobs:
   validate:
+    circleci_ip_ranges: true
     executor: java
     steps:
       - checkout


### PR DESCRIPTION
The PPUD team tightened the security such that the IP addresses of the CircleCI
jobs running our integration tests are outside of their accepted range. They
have whitelisted the list of known IP addresses CircleCI provides, so we add
here the circleci_ip_ranges flag which tells CircleCI to run our job from
within that range.