### PR TITLE
MRD-2763 Update HMPPS CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7
+  hmpps: ministryofjustice/hmpps@11
   slack: circleci/slack@4.10.1
   browser-tools: circleci/browser-tools@1.4
 
@@ -107,6 +107,8 @@ workflows:
           name: deploy_dev
           env: "dev"
           jira_update: true
+          pipeline_id: <<pipeline.id>>
+          pipeline_number: <<pipeline.number>>
           context: hmpps-common-vars
           filters:
             branches:
@@ -123,6 +125,8 @@ workflows:
           env: "preprod"
           jira_update: true
           jira_env_type: staging
+          pipeline_id: <<pipeline.id>>
+          pipeline_number: <<pipeline.number>>
           context:
             - hmpps-common-vars
             - hmpps-ppud-automation-api-preprod
@@ -139,6 +143,8 @@ workflows:
           env: "prod"
           jira_update: true
           jira_env_type: production
+          pipeline_id: <<pipeline.id>>
+          pipeline_number: <<pipeline.number>>
           slack_notification: true
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           context:


### PR DESCRIPTION
We're upgrading 4 major versions, from 7 to 11:
 - 7 > 8 breaking change: jobs using jira_update updated accordingly
 - 8 > 9 breaking change doesn't affect us: we don't use localstack executors
 - 9 > 10 breaking change doesn't affect us: this is not an npm project
 - 10 > 11 breaking change doesn't affect us: this is not an npm project