### PR TITLE
MRD-2768 Upgrade dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,6 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
-  implementation("commons-io:commons-io:2.18.0") // Address CVE-2021-29425
-
   // OAuth dependencies
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.security:spring-security-oauth2-client")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,8 +38,6 @@ dependencies {
   // OpenAPI dependencies
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
 
-  implementation("org.bouncycastle:bcprov-jdk18on:1.80") // Address CVE-2024-29857, CVE-2024-30172, CVE-2024-30171 present in 1.76
-
   testImplementation("org.mock-server:mockserver-netty:5.15.0")
   testImplementation("io.jsonwebtoken:jjwt:0.12.6")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
-  kotlin("plugin.spring") version "2.1.10"
-  id("org.sonarqube") version "6.0.1.5171"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0"
+  kotlin("plugin.spring") version "2.1.21"
+  id("org.sonarqube") version "6.2.0.5505"
   id("jacoco")
 }
 
@@ -22,7 +22,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
-  implementation("org.seleniumhq.selenium:selenium-java:4.29.0")
+  implementation("org.seleniumhq.selenium:selenium-java:4.34.0")
   implementation("io.github.bonigarcia:webdrivermanager:6.1.0")
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
@@ -30,19 +30,13 @@ dependencies {
 
   implementation("commons-io:commons-io:2.18.0") // Address CVE-2021-29425
 
-  // The dependencies below address the listed CVEs until the hmpps-gradle-spring-boot plug-in
-  // brings in a newer version of spring-boot with the fixes (it's already bringing the latest
-  // version of spring-boot, 3.5.0, but that doesn't have the fixes)
-  implementation("org.springframework:spring-web:6.2.8") // Address CVE-2025-41234
-  implementation("org.apache.tomcat.embed:tomcat-embed-core:10.1.42") // Address CVE-2025-49125 & CVE-2025-48988
-
   // OAuth dependencies
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.security:spring-security-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
   // OpenAPI dependencies
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
 
   implementation("org.bouncycastle:bcprov-jdk18on:1.80") // Address CVE-2024-29857, CVE-2024-30172, CVE-2024-30171 present in 1.76
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Non-breaking dependency upgrades have been applied here.

The bouncycastle dependency was pinned a while back to address a CVE. The
dependency originally came from webdrivermanager, which has since removed
bouncycastle as one of its dependencies, so we remove ours too.

The io-commons dependency no longer needs to be pinned, as the webdrivermanager
dependency we transitively get it from has stopped pulling the version with a
CVE.