### PR TITLE
MRD-2712 Enable bearer auth in Swagger UI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/OpenApiConfiguration.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.config
 
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springframework.boot.info.BuildProperties
 import org.springframework.context.annotation.Bean
@@ -26,4 +29,16 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
         .description("API to control the automation of PPUD frontend via Selenium")
         .contact(Contact().name("HMPPS Digital Studio").email("feedback@digital.justice.gov.uk")),
     )
+    .components(
+      Components().addSecuritySchemes(
+        "bearer-jwt",
+        SecurityScheme()
+          .type(SecurityScheme.Type.HTTP)
+          .scheme("bearer")
+          .bearerFormat("JWT")
+          .`in`(SecurityScheme.In.HEADER)
+          .name("Authorization"),
+      ),
+    )
+    .addSecurityItem(SecurityRequirement().addList("bearer-jwt"))
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/OpenApiDocsTest.kt
@@ -68,11 +68,8 @@ class OpenApiDocsTest {
       .expectBody().jsonPath("info.version").isEqualTo(DateTimeFormatter.ISO_DATE.format(LocalDate.now()))
   }
 
-  /* TODO: figure out if this is something we need to add or not
   @Test
   fun `the security scheme is setup for bearer tokens`() {
-    val bearerJwts = JSONArray()
-    bearerJwts.addAll(listOf("read", "write"))
     webTestClient.get()
       .uri("/v3/api-docs")
       .accept(MediaType.APPLICATION_JSON)
@@ -82,8 +79,6 @@ class OpenApiDocsTest {
       .jsonPath("$.components.securitySchemes.bearer-jwt.type").isEqualTo("http")
       .jsonPath("$.components.securitySchemes.bearer-jwt.scheme").isEqualTo("bearer")
       .jsonPath("$.components.securitySchemes.bearer-jwt.bearerFormat").isEqualTo("JWT")
-      .jsonPath("$.security[0].bearer-jwt")
-      .isEqualTo(bearerJwts)
+      .jsonPath("$.security[0].bearer-jwt").isEmpty
   }
-   */
 }


### PR DESCRIPTION
This will allow us to call the endpoints from Swagger UI (assuming we do so
with the auth token).