### PR TITLE
MRD-2906 Update police-forces HTML table ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/EditLookupsPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/EditLookupsPage.kt
@@ -21,9 +21,6 @@ internal class EditLookupsPage(driver: WebDriver) {
   @FindBy(id = "content_grdExtraBit")
   private lateinit var lookupsGridExtraBit: WebElement
 
-  @FindBy(id = "content_grdAddressLov")
-  private lateinit var lookupsGridAddressLov: WebElement
-
   private lateinit var configMap: Map<LookupName, LookupConfig>
 
   private data class LookupConfig(
@@ -40,7 +37,7 @@ internal class EditLookupsPage(driver: WebDriver) {
       LookupName.Ethnicities to LookupConfig("Ethnicity", lookupsGridLov, 2),
       LookupName.IndexOffences to LookupConfig("Index Offence", lookupsGridExtraBit, 2),
       LookupName.MappaLevels to LookupConfig("Mappa Level", lookupsGridLov, 2),
-      LookupName.PoliceForces to LookupConfig("Police Force", lookupsGridAddressLov, 2),
+      LookupName.PoliceForces to LookupConfig("Police Force", lookupsGridLov, 2),
       LookupName.ProbationServices to LookupConfig("Probation Service", lookupsGridExtraBit, 2),
       LookupName.ReleasedUnders to LookupConfig("Released Under", lookupsGridLov, 2),
     )


### PR DESCRIPTION
The ID of the HTML table containing the list of police forces in PPUD has
changed. Our code retrieving said values references that ID (it is hardcoded),
so we need to update it accordingly.