### PR TITLE
MRD-3174 Update hmpps gradle plug-in version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.6.0"
-  kotlin("plugin.spring") version "2.3.10"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.7.0"
+  kotlin("plugin.spring") version "2.3.20"
 }
 
 configurations {
@@ -31,37 +31,13 @@ dependencies {
   // OpenAPI dependencies
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16")
   // Temporary fix to address CVE-2026-0540, CVE-2025-15599, should be removable once
-  // springdoc-openapi-starter-webmvc-ui above pulls later version of swagger-ui
-  implementation("org.webjars:swagger-ui:5.32.1")
+  // springdoc-openapi-starter-webmvc-ui above pulls a later version of swagger-ui
+  constraints {
+    implementation("org.webjars:swagger-ui:5.32.1")
+  }
 
   // Temporary fix to address CVE-2025-68161 until we upgrade to spring-boot 4 or a 3.5.x with the fix is released
   implementation("org.apache.logging.log4j:log4j-api:2.25.3")
-
-  // Temporarily pinned to address CVE-2026-34483, CVE-2026-29129 and CVE-2026-25854, should be removable once
-  // spring-boot releases a 3.x version with the fix, or when we upgrade to spring-boot 4 (if the fix is included there)
-  implementation("org.apache.tomcat.embed:tomcat-embed-core:10.1.54")
-
-  // The following pinned netty dependencies are to address CVE-2026-33871 and CVE-2026-33870. Spring Boot 3.5.13
-  // addresses this, but it is currently only a few days old, so will wait for a bit more before releasing a new HMPPS
-  // plug-in version with it and pulling it here
-  implementation("io.netty:netty-buffer:4.2.12.Final")
-  implementation("io.netty:netty-codec:4.2.12.Final")
-  implementation("io.netty:netty-codec-dns:4.2.12.Final")
-  implementation("io.netty:netty-codec-http:4.2.12.Final")
-  implementation("io.netty:netty-codec-http2:4.2.12.Final")
-  implementation("io.netty:netty-codec-socks:4.2.12.Final")
-  implementation("io.netty:netty-common:4.2.12.Final")
-  implementation("io.netty:netty-handler:4.2.12.Final")
-  implementation("io.netty:netty-handler-proxy:4.2.12.Final")
-  implementation("io.netty:netty-resolver:4.2.12.Final")
-  implementation("io.netty:netty-resolver-dns:4.2.12.Final")
-  implementation("io.netty:netty-resolver-dns-classes-macos:4.2.12.Final")
-  implementation("io.netty:netty-resolver-dns-native-macos:4.2.12.Final")
-  implementation("io.netty:netty-resolver-dns-native-macos:4.2.12.Final")
-  implementation("io.netty:netty-transport:4.2.12.Final")
-  implementation("io.netty:netty-transport-classes-epoll:4.2.12.Final")
-  implementation("io.netty:netty-transport-native-epoll:4.2.12.Final")
-  implementation("io.netty:netty-transport-native-unix-common:4.2.12.Final")
 
   testImplementation("org.mock-server:mockserver-netty:5.15.0")
   testImplementation("io.jsonwebtoken:jjwt:0.13.0")

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,6 +14,8 @@ generic-service:
     DOCUMENT_MANAGEMENT_API_URL: https://document-api-dev.hmpps.service.justice.gov.uk
     FLIPT_DEFAULT_FLAG_VALUE: true
     ENVIRONMENT_NAME: dev
+    SPRINGDOC_APIDOCS_ENABLED: "true"
+    SPRINGDOC_SWAGGERUI_ENABLED: "true"
 
   scheduledDowntime:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,11 +36,14 @@ spring:
           hmpps-auth:
             token-uri: ${hmpps.auth.url}/oauth/token
 
-# Temporarily set when org.webjars:swagger-ui was set to 5.32.1 in build.gradle, as otherwise swagger-ui doesn't work.
-# Seems to be used in some places to build the path from which to retrieve resources, although it isn't officially
-# documented :/. Remove whenever no longer needed
 springdoc:
+  api-docs:
+    enabled: false
   swagger-ui:
+    enabled: false
+    # Temporarily set when org.webjars:swagger-ui was set to 5.32.1 in build.gradle, as otherwise swagger-ui doesn't work.
+    # Seems to be used in some places to build the path from which to retrieve resources, although it isn't officially
+    # documented :/. Remove whenever no longer needed
     version: 5.32.1
 
 server:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,3 +38,9 @@ documents:
 document-management:
   client:
     timeout: 2
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true


### PR DESCRIPTION
We update the version to 9.7.0, which pulls in a new Spring Boot version and
addresses various CVEs.

As part of these changes, we also disable docs-api and swagger-ui in the
non-dev environments, as they are unnecessary there and could expose us to
security vulnerabilities.