### PR TITLE
Turn off Slack failure messages for PRs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -97,7 +97,7 @@ jobs:
       slack_notification: 'true'
   notify_slack_of_failure:
     name: Notify Slack of failure
-    if: always() && contains(needs.*.result, 'failure')
+    if: always() && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure')
     needs:
       - helm_lint
       - validate


### PR DESCRIPTION
We're getting notifications in the Slack channel for every PR with a failure in
the pipeline. The whole team doesn't need to know of this, only of the ones
happening in main. Devs will get e-mails (or will keep an eye out) for failures
in their PRs.