### PR TITLE
MRD-3194: Upgrade latest gradle spring boot plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.7.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.7.1"
   kotlin("plugin.spring") version "2.3.20"
 }
 
@@ -16,9 +16,9 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
-  implementation("org.seleniumhq.selenium:selenium-java:4.41.0")
-  implementation("io.github.bonigarcia:webdrivermanager:6.3.3")
-  implementation("io.flipt:flipt-client-java:1.2.1")
+  implementation("org.seleniumhq.selenium:selenium-java:4.43.0")
+  implementation("io.github.bonigarcia:webdrivermanager:6.3.4")
+  implementation("io.flipt:flipt-client-java:1.3.1")
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")


### PR DESCRIPTION
CVEs Fixed (13):                                                                                                                                                                                                                                                                                                                                                                                                       
  CVE-2026-22740,MEDIUM,6.5,Spring Framework 6.2.18                                                                                                                                                                         
  CVE-2026-22741,LOW,3.1,Spring Framework 6.2.18                                                                                                                                                                            
  CVE-2026-22745,MEDIUM,5.3,Spring Framework 6.2.18                                                                                                                                                                         
  CVE-2026-22746,LOW,3.7,Spring Security 6.5.10    
  CVE-2026-22747,HIGH,8.1,Spring Security 6.5.10 / selenium upgrade                                                                                                                                                         
  CVE-2026-22748,MEDIUM,6.5,Spring Security 6.5.10                                                                                                                                                                          
  CVE-2026-22751,MEDIUM,4.8,Spring Security 6.5.10                                                                                                                                                                          
  CVE-2026-40971,LOW,,selenium upgrade                                                                                                                                                                                      
  CVE-2026-40972,HIGH,7.5,Spring Boot 3.5.14                                                                                                                                                                                
  CVE-2026-40973,HIGH,7.0,Spring Boot 3.5.14                                                                                                                                                                              
  CVE-2026-40974,LOW,,selenium upgrade                                                                                                                                                                                      
  CVE-2026-40975,HIGH,7.5,Spring Boot 3.5.14                                                                                                                                                                              
  CVE-2026-40977,MEDIUM,6.7,Spring Boot 3.5.14   

This project fixed 3 extra CVEs (CVE-2026-22747, CVE-2026-40971, CVE-2026-40974) compared to make-recall-decision-api - those came from the selenium-java 4.41.0 -> 4.43.0 bump carrying old Spring transitive deps.
                                                                                                                                                                                                                            
Newly appearing (pre-existing, no fix available): same as before — log4j-to-slf4j, DOMPurify in swagger-ui.           