### PR TITLE
MRD-3158 Upgrade to Spring Boot 4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.7.1"
-  kotlin("plugin.spring") version "2.3.20"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.2.5"
+  kotlin("plugin.spring") version "2.3.21"
 }
 
 configurations {
@@ -12,10 +12,14 @@ dependencyCheck {
 }
 
 dependencies {
+  implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  implementation("org.springframework.boot:spring-boot-starter-webclient")
   implementation("org.springframework.boot:spring-boot-starter-validation")
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
+  implementation("org.springframework.boot:spring-boot-jackson2")
+
   implementation("org.seleniumhq.selenium:selenium-java:4.43.0")
   implementation("io.github.bonigarcia:webdrivermanager:6.3.4")
   implementation("io.flipt:flipt-client-java:1.3.1")
@@ -26,18 +30,24 @@ dependencies {
   // OAuth dependencies
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.security:spring-security-oauth2-client")
-  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+  implementation("org.springframework.boot:spring-boot-starter-security-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-security-oauth2-resource-server")
 
   // OpenAPI dependencies
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16")
-  // Temporary fix to address CVE-2026-0540, CVE-2025-15599, should be removable once
-  // springdoc-openapi-starter-webmvc-ui above pulls a later version of swagger-ui
+  // Not sure if we're affected, but release notes on 10.2.1 version of hmpps-gradle-spring-boot
+  // reported some issues encountered and recommended pinning swagger-ui to 5.32.2 and not updating
+  // the springdoc dependency for now
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
   constraints {
-    implementation("org.webjars:swagger-ui:5.32.1")
+    implementation("org.webjars:swagger-ui:5.32.2")
   }
 
-  // Temporary fix to address CVE-2025-68161 until we upgrade to spring-boot 4 or a 3.5.x with the fix is released
-  implementation("org.apache.logging.log4j:log4j-api:2.25.3")
+  testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-webflux-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-webclient-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-validation-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-cache-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-data-redis-test")
 
   testImplementation("org.mock-server:mockserver-netty:5.15.0")
   testImplementation("io.jsonwebtoken:jjwt:0.13.0")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/HmppsPpudAutomationApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/HmppsPpudAutomationApiExceptionHandler.kt
@@ -184,7 +184,7 @@ class HmppsPpudAutomationApiExceptionHandler {
   }
 
   @ExceptionHandler(java.lang.Exception::class)
-  fun handleException(e: java.lang.Exception): ResponseEntity<ErrorResponse?>? {
+  fun handleException(e: java.lang.Exception): ResponseEntity<ErrorResponse> {
     log.error("Unexpected exception", e)
     return ResponseEntity
       .status(INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/OpenApiConfiguration.kt
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class OpenApiConfiguration(buildProperties: BuildProperties) {
-  private val version: String = buildProperties.version
+  private val version: String = buildProperties.version!!
 
   @Bean
   fun customOpenAPI(): OpenAPI = OpenAPI()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/WebClientConfiguration.kt
@@ -29,12 +29,12 @@ import java.util.concurrent.TimeoutException
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${ppud.url}") private val ppudUrl: String,
-  @Value("\${ppud.health.timeout}") private val ppudHealthTimeout: Long,
-  @Value("\${document-management.api.url}") private val documentManagementApiRootUri: String,
-  @Value("\${document-management.client.timeout}") private val documentManagementTimeout: Long,
-  @Value("\${document-management.health.timeout}") private val documentManagementHealthTimeout: Long,
-  @Value("\${document-management.client.headers.serviceName}") private val documentManagementHeaderServiceName: String,
+  @param:Value("\${ppud.url}") private val ppudUrl: String,
+  @param:Value("\${ppud.health.timeout}") private val ppudHealthTimeout: Long,
+  @param:Value("\${document-management.api.url}") private val documentManagementApiRootUri: String,
+  @param:Value("\${document-management.client.timeout}") private val documentManagementTimeout: Long,
+  @param:Value("\${document-management.health.timeout}") private val documentManagementHealthTimeout: Long,
+  @param:Value("\${document-management.client.headers.serviceName}") private val documentManagementHeaderServiceName: String,
 ) {
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/WebClientConfiguration.kt
@@ -40,7 +40,7 @@ class WebClientConfiguration(
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
 
-    fun <T> Mono<T>.withRetry(): Mono<T> = this
+    fun <T : Any> Mono<T>.withRetry(): Mono<T> = this
       .retryWhen(
         Retry.backoff(2, Duration.ofMillis(500))
           .filter(::shouldBeRetried)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/auth/PpudAuthConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/auth/PpudAuthConfig.kt
@@ -6,8 +6,8 @@ import org.springframework.context.annotation.Configuration
 // TODO re-organise properties, putting below ones under 'auth' (e.g. ppud.auth.username)
 @Configuration
 internal data class PpudAuthConfig(
-  @Value("\${ppud.username}") val username: String,
-  @Value("\${ppud.password}") val password: String,
-  @Value("\${ppud.admin.username}") val adminUsername: String,
-  @Value("\${ppud.admin.password}") val adminPassword: String,
+  @param:Value("\${ppud.username}") val username: String,
+  @param:Value("\${ppud.password}") val password: String,
+  @param:Value("\${ppud.admin.username}") val adminUsername: String,
+  @param:Value("\${ppud.admin.password}") val adminPassword: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/client/PpudClientConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/client/PpudClientConfig.kt
@@ -6,5 +6,5 @@ import org.springframework.context.annotation.Configuration
 // TODO re-organise properties, putting below ones under 'client' (e.g. ppud.client.url)
 @Configuration
 internal data class PpudClientConfig(
-  @Value("\${ppud.url}") val url: String,
+  @param:Value("\${ppud.url}") val url: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/postrelease/PostReleaseConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/postrelease/PostReleaseConfig.kt
@@ -5,8 +5,8 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 data class PostReleaseConfig(
-  @Value("\${ppud.release.postRelease.licenceType.determinate}") val determinateLicenceType: String,
-  @Value("\${ppud.release.postRelease.licenceType.dcr}") val dcrLicenceType: String,
-  @Value("\${ppud.release.postRelease.licenceType.ipp}") val ippLicenceType: String,
-  @Value("\${ppud.release.postRelease.licenceType.life}") val lifeLicenceType: String,
+  @param:Value("\${ppud.release.postRelease.licenceType.determinate}") val determinateLicenceType: String,
+  @param:Value("\${ppud.release.postRelease.licenceType.dcr}") val dcrLicenceType: String,
+  @param:Value("\${ppud.release.postRelease.licenceType.ipp}") val ippLicenceType: String,
+  @param:Value("\${ppud.release.postRelease.licenceType.life}") val lifeLicenceType: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/recall/RecallConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/recall/RecallConfig.kt
@@ -5,6 +5,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 data class RecallConfig(
-  @Value("\${ppud.recall.recallType.determinate}") val determinateRecallType: String,
-  @Value("\${ppud.recall.recallType.indeterminate}") val indeterminateRecallType: String,
+  @param:Value("\${ppud.recall.recallType.determinate}") val determinateRecallType: String,
+  @param:Value("\${ppud.recall.recallType.indeterminate}") val indeterminateRecallType: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/release/ReleaseConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/config/release/ReleaseConfig.kt
@@ -5,6 +5,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 data class ReleaseConfig(
-  @Value("\${ppud.release.releasedUnder.ippLicence}") val ippLicence: String,
-  @Value("\${ppud.release.releasedUnder.lifeLicence}") val lifeLicence: String,
+  @param:Value("\${ppud.release.releasedUnder.ippLicence}") val ippLicence: String,
+  @param:Value("\${ppud.release.releasedUnder.lifeLicence}") val lifeLicence: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/PpudUser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/PpudUser.kt
@@ -5,14 +5,14 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 
 data class PpudUser(
-  @Schema(
+  @param:Schema(
     description = "The full name of the user initiating this operation. This is the name as it appears in" +
       " PPUD selectors, e.g. 'Harry Smith', it is not the username.",
   )
   @field:NotBlank
   val fullName: String,
 
-  @Schema(
+  @param:Schema(
     description = "The PPUD team name that the user initiating this operation belongs to. It can be seen in" +
       " PPUD selectors in brackets after the user's name. e.g. Harry Smith(Recall Team).",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/HealthInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/HealthInfo.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.health
 
-import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.boot.info.BuildProperties
 import org.springframework.stereotype.Component
 
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class HealthInfo(buildProperties: BuildProperties) : HealthIndicator {
-  private val version: String = buildProperties.version
+  private val version: String = buildProperties.version!!
 
   override fun health(): Health = Health.up().withDetail("version", version).build()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PingHealthCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PingHealthCheck.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsppudautomationapi.health
 
 import io.netty.handler.timeout.TimeoutException
-import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.web.reactive.function.client.WebClient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PpudHealth.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PpudHealth.kt
@@ -7,6 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 
 @Component("ppud")
 class PpudHealth(
-  @Qualifier(value = "ppudHealthCheckWebClient") private val webClient: WebClient,
-  @Value("\${ppud.health.path}") private val path: String,
+  @param:Qualifier(value = "ppudHealthCheckWebClient") private val webClient: WebClient,
+  @param:Value("\${ppud.health.path}") private val path: String,
 ) : PingHealthCheck(webClient, path)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/ProductIdInfoContributor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/ProductIdInfoContributor.kt
@@ -6,7 +6,7 @@ import org.springframework.boot.actuate.info.InfoContributor
 import org.springframework.stereotype.Component
 
 @Component
-class ProductIdInfoContributor(@Value("\${product-id:default}") private val productId: String) : InfoContributor {
+class ProductIdInfoContributor(@param:Value("\${product-id:default}") private val productId: String) : InfoContributor {
 
   override fun contribute(builder: Info.Builder) {
     builder.withDetail("productId", productId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/PpudClientBase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/PpudClientBase.kt
@@ -33,7 +33,7 @@ internal abstract class PpudClientBase(
     operation: suspend () -> T,
   ): T {
     // Modal dialogs aren't scrollable, and their contents can be inaccessible by Selenium if outside of the viewport. Maximising the window to maximise the viewport.
-    driver.manage()?.window()?.maximize()
+    driver.manage().window().maximize()
 
     if (asAdmin) {
       loginAsAdmin()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/ReferenceDataPpudClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/ReferenceDataPpudClient.kt
@@ -22,7 +22,7 @@ internal class ReferenceDataPpudClient(
   errorPage: ErrorPage,
   loginPage: LoginPage,
   searchPage: SearchPage,
-  @Value("\${ppud.reference.valueToExclude}") private val valueToExclude: String,
+  @param:Value("\${ppud.reference.valueToExclude}") private val valueToExclude: String,
   private val adminPage: AdminPage,
   private val editLookupsPage: EditLookupsPage,
 ) : PpudClientBase(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/EditLookupsPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/EditLookupsPage.kt
@@ -38,7 +38,7 @@ internal class EditLookupsPage(driver: WebDriver, private val featureFlagService
   @FindBy(id = "content_grdAddressLov")
   private lateinit var lookupsGridAddressLov: WebElement
 
-  private lateinit var configMap: Map<LookupName, LookupConfig>
+  private var configMap: Map<LookupName, LookupConfig>
 
   private data class LookupConfig(
     val dropdownText: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/NewOffenderPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/NewOffenderPage.kt
@@ -21,10 +21,10 @@ internal class NewOffenderPage(
   private val driver: WebDriver,
   private val pageHelper: PageHelper,
   private val youngOffenderCalculator: YoungOffenderCalculator,
-  @Value("\${ppud.offender.immigrationStatus}") private val immigrationStatus: String,
-  @Value("\${ppud.offender.prisonerCategory}") private val prisonerCategory: String,
-  @Value("\${ppud.offender.status}") private val status: String,
-  @Value("\${ppud.offender.youngOffenderYes}") private val youngOffenderYes: String,
+  @param:Value("\${ppud.offender.immigrationStatus}") private val immigrationStatus: String,
+  @param:Value("\${ppud.offender.prisonerCategory}") private val prisonerCategory: String,
+  @param:Value("\${ppud.offender.status}") private val status: String,
+  @param:Value("\${ppud.offender.youngOffenderYes}") private val youngOffenderYes: String,
 ) {
 
   private val title = "New Offender"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/OffenderPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/OffenderPage.kt
@@ -36,14 +36,14 @@ internal class OffenderPage(
   private val dateFormatter: DateTimeFormatter,
   private val contentCreator: ContentCreator,
   private val youngOffenderCalculator: YoungOffenderCalculator,
-  @Value("\${ppud.url}") private val ppudUrl: String,
-  @Value("\${ppud.offender.caseworker.inCustody}") private val caseworkerInCustody: String,
-  @Value("\${ppud.offender.caseworker.ual}") private val caseworkerUal: String,
-  @Value("\${ppud.offender.immigrationStatus}") private val immigrationStatus: String,
-  @Value("\${ppud.offender.prisonerCategory}") private val prisonerCategory: String,
-  @Value("\${ppud.offender.status}") private val status: String,
-  @Value("\${ppud.offender.youngOffenderYes}") private val youngOffenderYes: String,
-  @Value("\${ppud.offender.youngOffenderNo}") private val youngOffenderNo: String,
+  @param:Value("\${ppud.url}") private val ppudUrl: String,
+  @param:Value("\${ppud.offender.caseworker.inCustody}") private val caseworkerInCustody: String,
+  @param:Value("\${ppud.offender.caseworker.ual}") private val caseworkerUal: String,
+  @param:Value("\${ppud.offender.immigrationStatus}") private val immigrationStatus: String,
+  @param:Value("\${ppud.offender.prisonerCategory}") private val prisonerCategory: String,
+  @param:Value("\${ppud.offender.status}") private val status: String,
+  @param:Value("\${ppud.offender.youngOffenderYes}") private val youngOffenderYes: String,
+  @param:Value("\${ppud.offender.youngOffenderNo}") private val youngOffenderNo: String,
 ) {
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/RecallPage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/RecallPage.kt
@@ -38,11 +38,11 @@ internal class RecallPage(
   private val dateFormatter: DateTimeFormatter,
   private val dateTimeFormatter: DateTimeFormatter,
   private val contentCreator: ContentCreator,
-  @Value("\${ppud.recall.revocationIssuedByOwner}") private val revocationIssuedByOwner: String,
-  @Value("\${ppud.recall.returnToCustodyNotificationMethod}") private val returnToCustodyNotificationMethod: String,
-  @Value("\${ppud.recall.nextUalCheckMonths}") private val nextUalCheckMonths: Long,
-  @Value("\${ppud.recall.documentType.document}") private val documentTypeDocument: String,
-  @Value("\${ppud.recall.documentType.email}") private val documentTypeEmail: String,
+  @param:Value("\${ppud.recall.revocationIssuedByOwner}") private val revocationIssuedByOwner: String,
+  @param:Value("\${ppud.recall.returnToCustodyNotificationMethod}") private val returnToCustodyNotificationMethod: String,
+  @param:Value("\${ppud.recall.nextUalCheckMonths}") private val nextUalCheckMonths: Long,
+  @param:Value("\${ppud.recall.documentType.document}") private val documentTypeDocument: String,
+  @param:Value("\${ppud.recall.documentType.email}") private val documentTypeEmail: String,
 ) {
   companion object {
     const val MINUTES_TEXT = "Minutes"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/ReleasePage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/pages/ReleasePage.kt
@@ -19,8 +19,8 @@ internal class ReleasePage(
   private val driver: WebDriver,
   private val pageHelper: PageHelper,
   private val dateFormatter: DateTimeFormatter,
-  @Value("\${ppud.release.category}") private val category: String,
-  @Value("\${ppud.release.releaseType}") private val releaseType: String,
+  @param:Value("\${ppud.release.category}") private val category: String,
+  @param:Value("\${ppud.release.releaseType}") private val releaseType: String,
 ) {
   private val pageDescription = "release page"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/DocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/DocumentService.kt
@@ -15,7 +15,7 @@ import kotlin.io.path.exists
 internal class DocumentService(
   private val documentManagementClient: DocumentManagementClient,
   private val uuidProvider: () -> UUID,
-  @Value("\${documents.storageDirectory}") private val documentsStorageDirectory: String,
+  @param:Value("\${documents.storageDirectory}") private val documentsStorageDirectory: String,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/referencedata/ReferenceDataCacheRefreshTask.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/referencedata/ReferenceDataCacheRefreshTask.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE, proxyMode = ScopedProxyMode.TARGET_CLASS)
 internal class ReferenceDataCacheRefreshTask(
-  @Qualifier("scheduledReferenceService") private val referenceService: ReferenceService,
+  @param:Qualifier("scheduledReferenceService") private val referenceService: ReferenceService,
 ) {
   suspend fun performTask() {
     try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,13 +5,15 @@ info.app:
 spring:
   application:
     name: hmpps-ppud-automation-api
-  codec:
-    max-in-memory-size: 10MB
+  http:
+    codecs:
+      max-in-memory-size: 10MB
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
+    datatype:
+      datetime:
+        WRITE_DATES_AS_TIMESTAMPS: false
 
   profiles:
     group:
@@ -35,16 +37,19 @@ spring:
         provider:
           hmpps-auth:
             token-uri: ${hmpps.auth.url}/oauth/token
+  web:
+    error:
+      include-message: always
 
 springdoc:
   api-docs:
     enabled: false
   swagger-ui:
     enabled: false
-    # Temporarily set when org.webjars:swagger-ui was set to 5.32.1 in build.gradle, as otherwise swagger-ui doesn't work.
+    # Temporarily set when org.webjars:swagger-ui was set to 5.32.2 in build.gradle, as otherwise swagger-ui doesn't work.
     # Seems to be used in some places to build the path from which to retrieve resources, although it isn't officially
     # documented :/. Remove whenever no longer needed
-    version: 5.32.1
+    version: 5.32.2
 
 server:
   port: 8080
@@ -57,8 +62,6 @@ server:
       protocol-header: x-forwarded-proto
       internal-proxies: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1|::1|100\.6[4-9]\.\d{1,3}\.\d{1,3}|100\.[7-9][0-9]{1}\.\d{1,3}\.\d{1,3}|100\.1[0-1][0-9]{1}\.\d{1,3}\.\d{1,3}|100\.12[0-7]\.\d{1,3}\.\d{1,3}
   shutdown: graceful
-  error:
-    include-message: always
 
 management:
   endpoints:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,10 +85,15 @@ management:
         time-to-live: 2000ms
 
 ppud:
+  username: ${PPUD_USERNAME:test-user}
+  password: ${PPUD_PASSWORD:test-password}
   url: https://internaltest.ppud.justice.gov.uk
   health:
     path: /Secure/MJSLogin.aspx
     timeout: 5
+  admin:
+    username: ${PPUD_ADMIN_USERNAME:test-admin-user}
+    password: ${PPUD_ADMIN_PASSWORD:test-admin-password}
   offender:
     caseworker:
       inCustody: "Recall Reps Packs(Recall 1)"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/domain/SentenceComparatorTest.kt
@@ -79,8 +79,8 @@ internal class SentenceComparatorTest {
       sentenceExpiryDate = existing.sentenceExpiryDate,
       sentenceLength = SentenceLength(
         existing.sentenceLength!!.partYears,
-        existing.sentenceLength!!.partMonths,
-        existing.sentenceLength!!.partDays,
+        existing.sentenceLength.partMonths,
+        existing.sentenceLength.partDays,
       ),
       sentencingCourt = existing.sentencingCourt,
       sentencedUnder = existing.sentencedUnder!!,
@@ -173,12 +173,12 @@ internal class SentenceComparatorTest {
         partMonths = differsOrTheSame(
           keyDeterminateFieldToBeDifferent,
           "sentenceLength.partMonths",
-          existing.sentenceLength!!.partMonths,
+          existing.sentenceLength.partMonths,
         ),
         partDays = differsOrTheSame(
           keyDeterminateFieldToBeDifferent,
           "sentenceLength.partDays",
-          existing.sentenceLength!!.partDays,
+          existing.sentenceLength.partDays,
         ),
       ),
       sentencingCourt = differsOrTheSame(keyDeterminateFieldToBeDifferent, "sentencingCourt", existing.sentencingCourt),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/DocumentManagementHealthTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/DocumentManagementHealthTest.kt
@@ -12,7 +12,7 @@ import org.mockserver.model.HttpError
 import org.mockserver.model.HttpRequest
 import org.mockserver.model.HttpResponse
 import org.mockserver.model.HttpStatusCode
-import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.health.contributor.Status
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PpudHealthTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/health/PpudHealthTest.kt
@@ -13,7 +13,7 @@ import org.mockserver.model.HttpRequest
 import org.mockserver.model.HttpResponse
 import org.mockserver.model.HttpStatusCode
 import org.mockserver.model.MediaType
-import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.health.contributor.Status
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/helpers/JwtAuthHelper.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 
 @Component
 class JwtAuthHelper {
-  private lateinit var keyPair: KeyPair
+  private var keyPair: KeyPair
 
   init {
     val gen = KeyPairGenerator.getInstance("RSA")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/IntegrationTestBase.kt
@@ -9,9 +9,9 @@ import org.mockserver.model.HttpRequest
 import org.mockserver.model.HttpResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.context.annotation.Import
 import org.springframework.core.io.ClassPathResource
 import org.springframework.http.HttpHeaders

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/OpenApiDocsTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -13,6 +14,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
 @ActiveProfiles("test")
 class OpenApiDocsTest {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/client/DocumentManagementClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/client/DocumentManagementClientTest.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 class DocumentManagementClientTest(
-  @Value("\${document-management.client.timeout}") private val timeout: Long,
+  @param:Value("\${document-management.client.timeout}") private val timeout: Long,
 ) : IntegrationTestBase() {
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/client/DocumentManagementClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/client/DocumentManagementClientTest.kt
@@ -54,7 +54,7 @@ class DocumentManagementClientTest(
       documentManagementClient.retrieveDocument(documentId)
     }
     assertTrue(
-      exception.message?.startsWith("500 Internal Server Error") == true,
+      exception.message.startsWith("500 Internal Server Error"),
       "Exception message was '${exception.message}'",
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderCreateTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_M
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_YOUNG_OFFENDER_NO
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_YOUNG_OFFENDER_YES
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.ppudKnownExistingOffender
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomBoolean
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomCroNumber
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomDate
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomNomsId
@@ -116,6 +117,7 @@ class OffenderCreateTest : IntegrationTestBase() {
           "firstNames" : "${randomString("firstNames")}",
           "gender" : "$PPUD_VALID_GENDER",
           "indexOffence" : "$PPUD_VALID_INDEX_OFFENCE",
+          "isInCustody" : "${randomBoolean()}",
           "mappaLevel" : "$PPUD_VALID_MAPPA_LEVEL",
           "prisonNumber" : "${randomPrisonNumber()}",
           "establishment" : "$PPUD_VALID_ESTABLISHMENT"
@@ -148,6 +150,7 @@ class OffenderCreateTest : IntegrationTestBase() {
         "firstNames" : "${randomString("firstNames")}",
         "gender" : "$PPUD_VALID_GENDER",
         "indexOffence" : "$PPUD_VALID_INDEX_OFFENCE",
+        "isInCustody" : "${randomBoolean()}",
         "mappaLevel" : "$PPUD_VALID_MAPPA_LEVEL",
         "nomsId" : null,
         "prisonNumber" : "${randomPrisonNumber()}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderSentenceCreateTest.kt
@@ -77,7 +77,7 @@ class OffenderSentenceCreateTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `given missing optional fields in request body when create offender called then 201 created is returned`() {
+  fun `given missing optional fields in request body when create sentence called then 201 created is returned`() {
     val offenderId = createTestOffenderInPpud()
     val requestBodyWithOnlyMandatoryFields =
       """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/offender/OffenderUpdateTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_G
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_VALID_GENDER_2
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_YOUNG_OFFENDER_NO
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.PPUD_YOUNG_OFFENDER_YES
+import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomBoolean
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomCroNumber
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomDate
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomNomsId
@@ -116,6 +117,7 @@ class OffenderUpdateTest : IntegrationTestBase() {
           "familyName" : "$FAMILY_NAME_PREFIX-$testRunId",
           "firstNames" : "${randomString("firstNames")}",
           "gender" : "$PPUD_VALID_GENDER",
+          "isInCustody" : "${randomBoolean()}",
           "prisonNumber" : "${randomPrisonNumber()}",
           "establishment" : "$PPUD_VALID_ESTABLISHMENT"
         }
@@ -138,6 +140,7 @@ class OffenderUpdateTest : IntegrationTestBase() {
           "firstNames" : "${randomString("firstNames")}",
           "gender" : "$PPUD_VALID_GENDER",
           "nomsId" : null,
+          "isInCustody" : "${randomBoolean()}",
           "prisonNumber" : "${randomPrisonNumber()}",
           "establishment" : "$PPUD_VALID_ESTABLISHMENT"
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/user/UserTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/integration/user/UserTest.kt
@@ -51,7 +51,7 @@ class UserTest : IntegrationTestBase() {
     assert(valuesExtractor.value != null)
     assert(valuesExtractor.value!!.isNotEmpty())
     // This is a user we already expect to exist, as we need it for other testing, so should be safe to use here
-    assertNotNull(valuesExtractor.value!!.find { it.get("fullName") == "Consider a Recall Test" })
+    assertNotNull(valuesExtractor.value!!.find { it["fullName"] == "Consider a Recall Test" })
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/OperationalPpudClientTest.kt
@@ -21,6 +21,8 @@ import org.mockito.kotlin.willReturnConsecutively
 import org.openqa.selenium.NotFoundException
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebDriver.Navigation
+import org.openqa.selenium.WebDriver.Options
+import org.openqa.selenium.WebDriver.Window
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.CreatedOffender
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.SearchResultOffender
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.Sentence
@@ -64,6 +66,12 @@ class OperationalPpudClientTest {
 
   @Mock
   private lateinit var webDriverNavigation: Navigation
+
+  @Mock
+  private lateinit var webDriverOptions: Options
+
+  @Mock
+  private lateinit var webDriverWindow: Window
 
   @Mock
   private lateinit var navigationTreeViewComponent: NavigationTreeViewComponent
@@ -152,6 +160,8 @@ class OperationalPpudClientTest {
     )
 
     given(driver.navigate()).willReturn(webDriverNavigation)
+    given(driver.manage()).willReturn(webDriverOptions)
+    given(webDriverOptions.window()).willReturn(webDriverWindow)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/ReferenceDataPpudClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/ppud/client/ReferenceDataPpudClientTest.kt
@@ -16,6 +16,8 @@ import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.then
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebDriver.Navigation
+import org.openqa.selenium.WebDriver.Options
+import org.openqa.selenium.WebDriver.Window
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.ppud.LookupName
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.ppud.pages.AdminPage
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.ppud.pages.EditLookupsPage
@@ -33,6 +35,12 @@ class ReferenceDataPpudClientTest {
 
   @Mock
   private lateinit var webDriverNavigation: Navigation
+
+  @Mock
+  private lateinit var webDriverOptions: Options
+
+  @Mock
+  private lateinit var webDriverWindow: Window
 
   @Mock
   private lateinit var loginPage: LoginPage
@@ -87,6 +95,8 @@ class ReferenceDataPpudClientTest {
     )
 
     given(driver.navigate()).willReturn(webDriverNavigation)
+    given(driver.manage()).willReturn(webDriverOptions)
+    given(webDriverOptions.window()).willReturn(webDriverWindow)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/ReferenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsppudautomationapi/service/ReferenceServiceTest.kt
@@ -12,13 +12,13 @@ import org.mockito.kotlin.then
 import org.mockito.kotlin.times
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.cache.interceptor.SimpleKey
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.domain.offender.SupportedCustodyType
 import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.ppud.LookupName
@@ -44,7 +44,7 @@ import uk.gov.justice.digital.hmpps.hmppsppudautomationapi.testdata.randomString
 @ContextConfiguration
 class ReferenceServiceTest {
 
-  @MockBean
+  @MockitoBean
   private lateinit var ppudClient: ReferenceDataPpudClient
 
   @Autowired


### PR DESCRIPTION
Upgrade to hmpps-gradle-spring-boot plug-in version 10.x, which involves
upgrading to Spring Boot 4.x. Various changes are made to support this,
including:
 - Using new module dependencies, as well as their -test analogues.
 - Upgrading to Spring Doc 3.x.
 - Updating config values. Some have been renamed, others had been renamed a
   while back and had been missed.
 - Various minor changes in the Kotlin code, mostly around nullability. Spring
   Boot has changed their nullability annotations in some libraries which cause
   Kotlin to warn or error in some places. All could be adapted without issue.
 - Some adaptations and corrections to test config and test data. Some of these
   were already wrong but weren't causing isssues before (not always clear
   why).