### PR TITLE
Set renovate for security only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ministryofjustice/hmpps-renovate-config:jvm"],
+  "extends": ["github>ministryofjustice/hmpps-renovate-config:jvm", "security:only-security-updates"],
   "prBodyTemplate": "{{{table}}}{{{notes}}}{{{warnings}}}{{{controls}}}",
-  "packageRules": [
-    {
-      "matchManagers": ["gradle"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non major Gradle dependencies",
-      "groupSlug": "all-gradle-minor-patch"
-    }
-  ],
   "schedule": [
     "* 7-19 * * 1-5"
   ]


### PR DESCRIPTION
We are setting up Dependabot for version and security updates and keeping
renovate for security updates only. This means there will be some overlap. We do
this because the tools work slightly differently and there have been reports
from people in HMPPS of the occasional vulnerability only addressed by one of
the tools.

We use both the HMPPS JVM renovate config preset and the renovate security only
one. The latest one in the list takes precedence in case of conflicts. We use
the first one to have it configured for a JVM repo and the second so that only
security update PRs are created.  