### PR TITLE
Address known CVEs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,11 +65,13 @@ dependencies {
 
   // OpenAPI dependencies
   // Not sure if we're affected, but release notes on 10.2.1 version of hmpps-gradle-spring-boot
-  // reported some issues encountered and recommended pinning swagger-ui to 5.32.2 and not updating
+  // reported some issues encountered and recommended pinning swagger-ui to 5.32.11 and not updating
   // the springdoc dependency for now
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
   constraints {
-    implementation("org.webjars:swagger-ui:5.32.2")
+    implementation("org.webjars:swagger-ui:5.32.11") {
+      because("Address DOMPurify CVEs (CVE-2026-65898 through CVE-2026-65903 and CVE-2026-66010) - bundles DOMPurify 3.4.12")
+    }
   }
 
   // hmpps-spring-boot plugin explicitly forcing the tomcat-embed-core version, so we can't override using constraints
@@ -85,6 +87,25 @@ dependencies {
       strictly("11.0.24")
     }
     because("Address CVE-2026-59084 - can be removed once uk.gov.justice.hmpps.gradle-spring-boot to 11.0.x ")
+  }
+
+  implementation("org.apache.httpcomponents.client5:httpclient5") {
+    version {
+      strictly("5.6.2")
+    }
+    because("Address CVEs CVE-2026-54428 & CVE-2026-54399 - review when upgrading webdrivermanager past 6.3.4")
+  }
+  implementation("org.apache.httpcomponents.core5:httpcore5") {
+    version {
+      strictly("5.4.3")
+    }
+    because("Address CVEs CVE-2026-54428 & CVE-2026-54399 - review when upgrading webdrivermanager past 6.3.4")
+  }
+  implementation("org.apache.httpcomponents.core5:httpcore5-h2") {
+    version {
+      strictly("5.4.3")
+    }
+    because("Address CVEs CVE-2026-54428 & CVE-2026-54399 - review when upgrading webdrivermanager past 6.3.4")
   }
 
   testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,10 +46,10 @@ springdoc:
     enabled: false
   swagger-ui:
     enabled: false
-    # Temporarily set when org.webjars:swagger-ui was set to 5.32.2 in build.gradle, as otherwise swagger-ui doesn't work.
+    # Temporarily set when org.webjars:swagger-ui was set to 5.32.11 in build.gradle, as otherwise swagger-ui doesn't work.
     # Seems to be used in some places to build the path from which to retrieve resources, although it isn't officially
     # documented :/. Remove whenever no longer needed
-    version: 5.32.2
+    version: 5.32.11
 
 server:
   port: 8080


### PR DESCRIPTION
Pinning Swagger-UI, httpclient5 and httpcore5 versions to address CVEs. CVEs not
addressed:
- https://github.com/advisories/GHSA-rpf9-hrjr-88fv: not worth addressing, as v11.x of the HMPPS gradle plug-in
does so by suppressing it, so we can wait for our upgrade to that version of the
plug-in instead.
- https://github.com/advisories/GHSA-xw83-8gp3-pg5q, https://github.com/advisories/GHSA-pcmr-4mmx-225x: low severity, requires newer version of Spring
Boot, which involves some breaking changes. Will be gone on plug-in upgrade.
- CVE-2026-59903: moderate severity. Fix available, but release fixing it isn't
yet a week old. I don't think the CVE actually affects us (can't find references
to CorsHandler or Vary headers in MoJ code, both of which are involved in the
explit), so going to wait for another week.
- https://github.com/advisories/GHSA-55q2-fjhq-7xh7: vulnerability in DOMPurify, a Javascript package bundled
by the swagger-ui dependency, so we can't override it. There are no swagger-ui
releases updating their version of DOMPurify, so will have to wait for now.